### PR TITLE
Add release drafter workflow

### DIFF
--- a/.github/release-drafter/config.yml
+++ b/.github/release-drafter/config.yml
@@ -1,0 +1,23 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES
+
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: minor
+
+categories:
+  - title: ':arrow_up: Dependencies'
+    label: dependencies
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,37 @@
+name: Release Drafter
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+     - main
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    strategy:
+      matrix:
+        prerelease:
+          - true
+          - false
+
+    permissions:
+      # write permission is required to create a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # Using a fork, see https://github.com/release-drafter/release-drafter/pull/1385
+      - uses: leukeleu/release-drafter@filter-draft-releases
+        with:
+          config-name: release-drafter/config.yml
+          prerelease: ${{ matrix.prerelease }}
+          prerelease-identifier: ${{ matrix.prerelease && 'rc' || '' }}
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 1


### PR DESCRIPTION
I've also added the `patch`, `minor`, `major` and `skip-release` labels to https://github.com/leukeleu/leukeleu-hidp/labels. The last one is to avoid unwanted version bumps from merged dependabot updates.