### PR TITLE
Rename the auth namespace to hidp_accounts

### DIFF
--- a/backend/hidp/accounts/auth_urls.py
+++ b/backend/hidp/accounts/auth_urls.py
@@ -15,14 +15,14 @@ This module also defines the namespace `auth` for these URLs.
 
 Include this namespace when reversing URLs, for example:
 
-    reverse("auth:login")
+    reverse("hidp_accounts:login")
 """
 
 from django.urls import path
 
 from . import views
 
-app_name = "auth"
+app_name = "hidp_accounts"
 
 urlpatterns = [
     path("login/", views.LoginView.as_view(), name="login"),

--- a/backend/hidp/accounts/templates/accounts/login.html
+++ b/backend/hidp/accounts/templates/accounts/login.html
@@ -6,9 +6,9 @@
 </head>
 <body>
   {% if request.user.is_authenticated %}
-  <form action="{%  url 'auth:logout' %}" method="post">
+  <form action="{%  url 'hidp_accounts:logout' %}" method="post">
     {% csrf_token %}
-    <input type="hidden" name="next" value="{% url 'auth:login' %}">
+    <input type="hidden" name="next" value="{% url 'hidp_accounts:login' %}">
     <p>
       {% blocktranslate %}
       You are currently logged in as {{ user }}.

--- a/backend/hidp/settings.py
+++ b/backend/hidp/settings.py
@@ -147,7 +147,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # Login and logout settings
-LOGIN_URL = "auth:login"
+LOGIN_URL = "hidp_accounts:login"
 
 # Default login and logout redirect URL
 LOGIN_REDIRECT_URL = "/"

--- a/backend/hidp/urls.py
+++ b/backend/hidp/urls.py
@@ -8,7 +8,7 @@ from .router import router
 
 urlpatterns = [
     # Project
-    path("", RedirectView.as_view(pattern_name="auth:login"), name="root"),
+    path("", RedirectView.as_view(pattern_name="hidp_accounts:login"), name="root"),
     path("", include(hidp_urls)),
     *router.urls,
     # Django Admin

--- a/backend/tests/smoke_tests/test_accounts/test_login.py
+++ b/backend/tests/smoke_tests/test_accounts/test_login.py
@@ -13,9 +13,10 @@ class TestLogin(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = user_factories.UserFactory()
+        cls.login_url = reverse("hidp_accounts:login")
 
     def test_get_login(self):
-        response = self.client.get(reverse("auth:login"))
+        response = self.client.get(self.login_url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "accounts/login.html")
         self.assertIn("form", response.context)
@@ -23,7 +24,7 @@ class TestLogin(TestCase):
 
     def test_valid_login_default_redirect(self):
         response = self.client.post(
-            reverse("auth:login"),
+            self.login_url,
             {
                 "username": self.user.email,
                 "password": "P@ssw0rd!",
@@ -33,7 +34,7 @@ class TestLogin(TestCase):
 
     def test_valid_login_safe_next_param(self):
         response = self.client.post(
-            f"{reverse('auth:login')}",
+            self.login_url,
             {
                 "username": self.user.email,
                 "password": "P@ssw0rd!",
@@ -44,7 +45,7 @@ class TestLogin(TestCase):
 
     def test_valid_login_unsafe_next_param(self):
         response = self.client.post(
-            f"{reverse('auth:login')}",
+            self.login_url,
             {
                 "username": self.user.email,
                 "password": "P@ssw0rd!",
@@ -55,7 +56,7 @@ class TestLogin(TestCase):
 
     def test_invalid_login(self):
         response = self.client.post(
-            reverse("auth:login"),
+            self.login_url,
             {
                 "username": self.user.email,
                 "password": "invalid",

--- a/backend/tests/smoke_tests/test_accounts/test_logout.py
+++ b/backend/tests/smoke_tests/test_accounts/test_logout.py
@@ -14,16 +14,17 @@ class TestLogout(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = user_factories.UserFactory()
+        cls.logout_url = reverse("hidp_accounts:logout")
 
     def test_get_logout(self):
         """GET is not allowed for the logout view."""
-        response = self.client.get(reverse("auth:logout"))
+        response = self.client.get(self.logout_url)
         self.assertEqual(HTTPStatus.METHOD_NOT_ALLOWED, response.status_code)
 
     def test_post_logout_no_login(self):
         """POST is allowed for the logout view, even if the user is not logged in."""
         session_key = self.client.session.session_key
-        response = self.client.post(reverse("auth:logout"))
+        response = self.client.post(self.logout_url)
         self.assertRedirects(response, "/", fetch_redirect_response=False)
         self.assertNotEqual(session_key, self.client.session.session_key)
 
@@ -31,14 +32,14 @@ class TestLogout(TestCase):
         """POST is allowed for the logout view."""
         self.client.force_login(self.user)
         session_key = self.client.session.session_key
-        response = self.client.post(reverse("auth:logout"))
+        response = self.client.post(self.logout_url)
         self.assertRedirects(response, "/", fetch_redirect_response=False)
         self.assertNotEqual(session_key, self.client.session.session_key)
 
     def test_post_logout_with_safe_next_param(self):
         """Redirects to the next url, if it's safe."""
         response = self.client.post(
-            reverse("auth:logout"),
+            self.logout_url,
             {"next": "/example/"},
         )
         self.assertRedirects(response, "/example/", fetch_redirect_response=False)
@@ -46,7 +47,7 @@ class TestLogout(TestCase):
     def test_post_logout_with_unsafe_next_param(self):
         """Redirects to the default url, if the next url is unsafe."""
         response = self.client.post(
-            reverse("auth:logout"),
+            self.logout_url,
             {"next": "https://example.com/"},
         )
         self.assertRedirects(response, "/", fetch_redirect_response=False)

--- a/backend/tests/smoke_tests/test_root.py
+++ b/backend/tests/smoke_tests/test_root.py
@@ -6,5 +6,5 @@ class TestRoot(TestCase):
     def test_root(self):
         response = self.client.get("/")
         self.assertRedirects(
-            response, reverse("auth:login"), fetch_redirect_response=False
+            response, reverse("hidp_accounts:login"), fetch_redirect_response=False
         )


### PR DESCRIPTION
This makes it less likely to clash user namespaces

Similar to #17, renaming things that are overly generic and are likely to clash with user code (i.e. wrapping projects)