### PR TITLE
Require Django 5 or higher (but not 6)

### DIFF
--- a/packages/hidp/requirements.txt
+++ b/packages/hidp/requirements.txt
@@ -1,3 +1,3 @@
-Django~=4.2.0
+Django~=5.0
 django-oauth-toolkit~=2.4.0
 psycopg2-binary~=2.9.6

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -1,4 +1,4 @@
-Django~=4.2.0
+Django~=5.0
 django-email-bandit~=2.0.0
 djangorestframework~=3.14.0
 django-filter~=24.2


### PR DESCRIPTION
Django 5 adds [GeneratedField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#generatedfield), which will be useful to support unique, case-insensitive, email addresses across databases (but not Oracle).

Ref: HIDP-61