### PR TITLE
HIDP-46 Add ratelimit to login and logout views

### DIFF
--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -1,12 +1,21 @@
+from django_ratelimit.decorators import ratelimit
+
 from django.contrib.auth import views as auth_views
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 
 from ..config import oidc_clients
 from . import auth as hidp_auth
 from .forms import AuthenticationForm
 
 
+@method_decorator(
+    ratelimit(key="post:username", rate="10/m", method="POST"), name="post"
+)
+@method_decorator(ratelimit(key="ip", rate="10/s", method="POST"), name="post")
+@method_decorator(ratelimit(key="ip", rate="30/m", method="POST"), name="post")
+@method_decorator(ratelimit(key="ip", rate="100/15m", method="POST"), name="post")
 class LoginView(auth_views.LoginView):
     """
     Display the login form and handle the login action.
@@ -86,6 +95,8 @@ class LoginView(auth_views.LoginView):
         return HttpResponseRedirect(self.get_success_url())
 
 
+@method_decorator(ratelimit(key="ip", rate="10/s", method="POST"), name="post")
+@method_decorator(ratelimit(key="ip", rate="30/m", method="POST"), name="post")
 class LogoutView(auth_views.LogoutView):
     """
     Logs out the user, regardless of whether a user is logged in.


### PR DESCRIPTION
Adds rate limits to login and logout views.

As the package might be used by applications with users from one company, we want to have a higher rate limit on `ip`. 
For now I chose a limit of:
- ~~`3/s`~~ `10/s` burst
- `30/m` burst
- ~~`300/h`~~ `100/15m` 

Having a higher 'bucket' size (second if rate limit is based on `s`, hour if it's based on `h`), increases the lockout time. There is no separate lockout setting, so the lockout is the 'bucket' size . If someone tries to circumvent the ~~`3/s`~~ `10/s` or `30/m` rate limits by spreading out their requests, they will be locked out for ~~an hour~~ 15 min after ~~300~~ 100 requests.

Also, for the login form, there is a separate rate limit on the filled in username: `10/m`. So if someone tries to brute force one specific account (even from different IPs), they cannot. It is unlikely that a real user fails to login 10 times per minute.