### PR TITLE
HIDP-90 Fetch user info

### DIFF
--- a/packages/hidp/hidp/federated/views.py
+++ b/packages/hidp/hidp/federated/views.py
@@ -82,14 +82,17 @@ class OIDCAuthenticationCallbackView(OIDCMixin, View):
     ]
 
     def get(self, request, provider_key):
-        tokens, claims = authorization_code_flow.handle_authentication_callback(
-            request,
-            client=self.get_oidc_client(provider_key),
-            redirect_uri=self.get_redirect_uri(provider_key),
+        tokens, claims, user_info = (
+            authorization_code_flow.handle_authentication_callback(
+                request,
+                client=self.get_oidc_client(provider_key),
+                redirect_uri=self.get_redirect_uri(provider_key),
+            )
         )
         return JsonResponse(
             {
                 "tokens": tokens,
                 "claims": claims,
+                "user_info": user_info,
             }
         )

--- a/packages/hidp/tests/smoke_tests/test_federated/test_views.py
+++ b/packages/hidp/tests/smoke_tests/test_federated/test_views.py
@@ -106,6 +106,9 @@ class TestOIDCAuthenticationCallbackView(TestCase):
             {
                 "claims": "claims",
             },
+            {
+                "user_info": "user_info",
+            },
         ),
     )
     def test_calls_handle_authentication_callback(


### PR DESCRIPTION
This is the final required step of the OIDC flow, retrieving the user data from the user info endpoint. This data is usually already included in the id_token, but *might* not be so it's still good practice to get it from the provider.