### PR TITLE
HIDP-99 Add default rate limits and apply to urls and views

### DIFF
--- a/packages/hidp/hidp/accounts/oidc_provider_urls.py
+++ b/packages/hidp/hidp/accounts/oidc_provider_urls.py
@@ -21,52 +21,33 @@ Does **not** include application management views. Applications can be managed
 using the Django Admin interface.
 """
 
-from django_ratelimit.decorators import ratelimit
 from oauth2_provider import views as oauth2_views
 
 from django.urls import path
+
+from hidp.rate_limit.decorators import rate_limit_default, rate_limit_strict
 
 app_name = "oauth2_provider"
 
 base_urlpatterns = [
     path(
         "authorize/",
-        ratelimit(key="ip", method=ratelimit.ALL, rate="10/s")(
-            ratelimit(key="ip", method=ratelimit.ALL, rate="30/m")(
-                ratelimit(key="ip", method=ratelimit.ALL, rate="100/15m")(
-                    oauth2_views.AuthorizationView.as_view()
-                )
-            )
-        ),
+        rate_limit_strict(oauth2_views.AuthorizationView.as_view()),
         name="authorize",
     ),
     path(
         "token/",
-        ratelimit(key="ip", method="POST", rate="10/s")(
-            ratelimit(key="ip", method="POST", rate="30/m")(
-                ratelimit(key="ip", method="POST", rate="100/15m")(
-                    oauth2_views.TokenView.as_view()
-                )
-            )
-        ),
+        rate_limit_strict(oauth2_views.TokenView.as_view()),
         name="token",
     ),
     path(
         "revoke_token/",
-        ratelimit(key="ip", method="POST", rate="10/s")(
-            ratelimit(key="ip", method="POST", rate="30/m")(
-                oauth2_views.RevokeTokenView.as_view()
-            )
-        ),
+        rate_limit_default(oauth2_views.RevokeTokenView.as_view()),
         name="revoke-token",
     ),
     path(
         "introspect/",
-        ratelimit(key="ip", method=ratelimit.ALL, rate="10/s")(
-            ratelimit(key="ip", method=ratelimit.ALL, rate="30/m")(
-                oauth2_views.IntrospectTokenView.as_view()
-            )
-        ),
+        rate_limit_default(oauth2_views.IntrospectTokenView.as_view()),
         name="introspect",
     ),
 ]
@@ -74,38 +55,22 @@ base_urlpatterns = [
 oidc_urlpatterns = [
     path(
         ".well-known/openid-configuration",
-        ratelimit(key="ip", method=ratelimit.ALL, rate="10/s")(
-            ratelimit(key="ip", method=ratelimit.ALL, rate="30/m")(
-                oauth2_views.ConnectDiscoveryInfoView.as_view()
-            )
-        ),
+        rate_limit_default(oauth2_views.ConnectDiscoveryInfoView.as_view()),
         name="oidc-connect-discovery-info",
     ),
     path(
         ".well-known/jwks.json",
-        ratelimit(key="ip", method=ratelimit.ALL, rate="10/s")(
-            ratelimit(key="ip", method=ratelimit.ALL, rate="30/m")(
-                oauth2_views.JwksInfoView.as_view()
-            )
-        ),
+        rate_limit_default(oauth2_views.JwksInfoView.as_view()),
         name="jwks-info",
     ),
     path(
         "userinfo/",
-        ratelimit(key="ip", method=ratelimit.ALL, rate="10/s")(
-            ratelimit(key="ip", method=ratelimit.ALL, rate="30/m")(
-                oauth2_views.UserInfoView.as_view()
-            )
-        ),
+        rate_limit_default(oauth2_views.UserInfoView.as_view()),
         name="user-info",
     ),
     path(
         "logout/",
-        ratelimit(key="ip", method=ratelimit.ALL, rate="10/s")(
-            ratelimit(key="ip", method=ratelimit.ALL, rate="30/m")(
-                oauth2_views.RPInitiatedLogoutView.as_view()
-            )
-        ),
+        rate_limit_default(oauth2_views.RPInitiatedLogoutView.as_view()),
         name="rp-initiated-logout",
     ),
 ]

--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -5,6 +5,8 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 
+from hidp.rate_limit.decorators import rate_limit_default, rate_limit_strict
+
 from ..config import oidc_clients
 from . import auth as hidp_auth
 from .forms import AuthenticationForm
@@ -13,9 +15,7 @@ from .forms import AuthenticationForm
 @method_decorator(
     ratelimit(key="post:username", rate="10/m", method="POST"), name="post"
 )
-@method_decorator(ratelimit(key="ip", rate="10/s", method="POST"), name="post")
-@method_decorator(ratelimit(key="ip", rate="30/m", method="POST"), name="post")
-@method_decorator(ratelimit(key="ip", rate="100/15m", method="POST"), name="post")
+@method_decorator(rate_limit_strict, name="dispatch")
 class LoginView(auth_views.LoginView):
     """
     Display the login form and handle the login action.
@@ -95,8 +95,7 @@ class LoginView(auth_views.LoginView):
         return HttpResponseRedirect(self.get_success_url())
 
 
-@method_decorator(ratelimit(key="ip", rate="10/s", method="POST"), name="post")
-@method_decorator(ratelimit(key="ip", rate="30/m", method="POST"), name="post")
+@method_decorator(rate_limit_default, name="dispatch")
 class LogoutView(auth_views.LogoutView):
     """
     Logs out the user, regardless of whether a user is logged in.

--- a/packages/hidp/hidp/federated/views.py
+++ b/packages/hidp/hidp/federated/views.py
@@ -1,5 +1,3 @@
-from django_ratelimit.decorators import ratelimit
-
 from django.http import (
     Http404,
     HttpResponseBadRequest,
@@ -9,6 +7,8 @@ from django.http import (
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
+
+from hidp.rate_limit.decorators import rate_limit_strict
 
 from ..config import oidc_clients
 from .oidc import authorization_code_flow
@@ -39,9 +39,7 @@ class OIDCMixin:
         )
 
 
-@method_decorator(ratelimit(key="ip", rate="10/s", method="POST"), name="post")
-@method_decorator(ratelimit(key="ip", rate="30/m", method="POST"), name="post")
-@method_decorator(ratelimit(key="ip", rate="100/15m", method="POST"), name="post")
+@method_decorator(rate_limit_strict, name="dispatch")
 class OIDCAuthenticationRequestView(OIDCMixin, View):
     """
     Initiates an OpenID Connect Authorization Code Flow authentication request.
@@ -67,9 +65,7 @@ class OIDCAuthenticationRequestView(OIDCMixin, View):
         )
 
 
-@method_decorator(ratelimit(key="ip", rate="10/s", method="GET"), name="get")
-@method_decorator(ratelimit(key="ip", rate="30/m", method="GET"), name="get")
-@method_decorator(ratelimit(key="ip", rate="100/15m", method="GET"), name="get")
+@method_decorator(rate_limit_strict, name="dispatch")
 class OIDCAuthenticationCallbackView(OIDCMixin, View):
     """
     Handles the callback response from an OpenID Connect Authorization Code Flow

--- a/packages/hidp/hidp/rate_limit/decorators.py
+++ b/packages/hidp/hidp/rate_limit/decorators.py
@@ -1,0 +1,24 @@
+from django_ratelimit.decorators import ratelimit
+
+_default_rate_limits = [
+    ratelimit(key="ip", method=ratelimit.UNSAFE, rate="10/s"),
+    ratelimit(key="ip", method=ratelimit.UNSAFE, rate="30/m"),
+]
+
+
+def _apply_rate_limits(*rate_limits, view):
+    for rate_limit in rate_limits:
+        view = rate_limit(view)
+    return view
+
+
+def rate_limit_default(view):
+    return _apply_rate_limits(*_default_rate_limits, view=view)
+
+
+def rate_limit_strict(view):
+    return _apply_rate_limits(
+        *_default_rate_limits,
+        ratelimit(key="ip", method=ratelimit.ALL, rate="100/15m"),
+        view=view,
+    )

--- a/packages/hidp/tests/unit_tests/test_rate_limit/test_decorators.py
+++ b/packages/hidp/tests/unit_tests/test_rate_limit/test_decorators.py
@@ -1,0 +1,33 @@
+from django.test import RequestFactory, TestCase
+
+from hidp.rate_limit.decorators import rate_limit_default, rate_limit_strict
+
+
+@rate_limit_default
+def rate_limit_default_view(request):
+    pass
+
+
+@rate_limit_strict
+def rate_limit_strict_view(request):
+    pass
+
+
+class TestRateLimitDecorators(TestCase):
+    def test_rate_limit_default(self):
+        request = RequestFactory().get("/")
+        rate_limit_default_view(request)
+        self.assertIsNotNone(getattr(request, "limited", None))
+
+        request = RequestFactory().post("/")
+        rate_limit_default_view(request)
+        self.assertIsNotNone(getattr(request, "limited", None))
+
+    def test_rate_limit_strict(self):
+        request = RequestFactory().get("/")
+        rate_limit_strict_view(request)
+        self.assertIsNotNone(getattr(request, "limited", None))
+
+        request = RequestFactory().post("/")
+        rate_limit_strict_view(request)
+        self.assertIsNotNone(getattr(request, "limited", None))


### PR DESCRIPTION
Adds custom decorators that use the ratelimit decorator from django-ratelimit to not have to define the same rate limits everywhere.

- [x] Add test for custom decorators