### PR TITLE
Replace most instances of JWK(s) (data) with signing keys

### DIFF
--- a/packages/hidp/hidp/config/oidc_clients.py
+++ b/packages/hidp/hidp/config/oidc_clients.py
@@ -16,7 +16,7 @@ def configure_oidc_clients(*clients, eagerly_provision_jwk_store=False):
         *clients (OIDCClient):
             One or more OIDCClient instances to register.
         eagerly_provision_jwk_store (bool):
-            Whether to eagerly load the JWK data for the registered clients.
+            Whether to eagerly load the signing keys for the registered clients.
             This is useful to ensure that the keys are loaded at application startup
             instead of the first time they are needed.
 

--- a/packages/hidp/hidp/federated/management/commands/refresh_oidc_clients_jwks.py
+++ b/packages/hidp/hidp/federated/management/commands/refresh_oidc_clients_jwks.py
@@ -4,7 +4,7 @@ from ...oidc import jwks
 
 
 class Command(BaseCommand):
-    help = "Refresh the JWKs for all OIDC clients."
+    help = "Refresh the signing keys for all OIDC clients."
 
     def handle(self, *args, **options):
         jwks.refresh_registered_oidc_clients_jwks(stdout=self.stdout)

--- a/packages/hidp/hidp/federated/oidc/authorization_code_flow.py
+++ b/packages/hidp/hidp/federated/oidc/authorization_code_flow.py
@@ -382,7 +382,7 @@ def parse_id_token(raw_id_token, *, client):
     keys = jwks.get_oidc_client_jwks(client)
     if keys is None:
         raise OIDCError(
-            f"Unable to get JWKs for {client.provider_key!r}."
+            f"Unable to get signing keys for {client.provider_key!r}."
             " The ID Token cannot be validated."
         )
 

--- a/packages/hidp/tests/unit_tests/test_federated/test_oidc/test_authorization_code_flow.py
+++ b/packages/hidp/tests/unit_tests/test_federated/test_oidc/test_authorization_code_flow.py
@@ -470,11 +470,12 @@ class TestParseIdToken(TestCase):
         return token.serialize()
 
     def test_unable_to_get_jwks(self, mock_get_oidc_client_jwks):
-        """Raises an OIDCError when the JWKs cannot be retrieved."""
+        """Raises an OIDCError when the signing keys cannot be retrieved."""
         mock_get_oidc_client_jwks.return_value = None
         with self.assertRaisesMessage(
             exceptions.OIDCError,
-            "Unable to get JWKs for 'example'. The ID Token cannot be validated.",
+            "Unable to get signing keys for 'example'."
+            " The ID Token cannot be validated.",
         ):
             authorization_code_flow.parse_id_token(
                 "id_token",


### PR DESCRIPTION
Only keep using the JWK(S) terms when it refers to the endpoint and the actual cache