### PR TITLE
Use a different database name to prevent InconsistentMigrationHistory

### DIFF
--- a/packages/hidp/tests/test_settings.py
+++ b/packages/hidp/tests/test_settings.py
@@ -84,7 +84,7 @@ SECRET_KEY = "secret-key-only-for-testing"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "postgres",
+        "NAME": "test_hidp",
         "USER": "postgres",
         "PASSWORD": "postgres",
         "HOST": "localhost" if "CI" in os.environ else "postgres",


### PR DESCRIPTION
This happens in development because the package testproject would see the sandbox database and they have different user models.