### PR TITLE
Update forms import, to prevent import wrapping

### DIFF
--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -13,12 +13,7 @@ from django.views import generic
 from ..config import oidc_clients
 from ..rate_limit.decorators import rate_limit_default, rate_limit_strict
 from . import auth as hidp_auth
-from .forms import (
-    AuthenticationForm,
-    PasswordResetForm,
-    PasswordResetRequestForm,
-    UserCreationForm,
-)
+from . import forms
 
 
 @method_decorator(ratelimit(key="ip", rate="2/s", method="POST"), name="post")
@@ -36,7 +31,7 @@ class RegistrationView(auth_views.RedirectURLMixin, generic.FormView):
     reason for the failure and the user can try again.
     """
 
-    form_class = UserCreationForm
+    form_class = forms.UserCreationForm
     template_name = "accounts/register.html"
     next_page = "/"
 
@@ -85,7 +80,7 @@ class LoginView(auth_views.LoginView):
     """
 
     # The form class to use for authentication
-    form_class = AuthenticationForm
+    form_class = forms.AuthenticationForm
     # The template to use for displaying the login form
     template_name = "accounts/login.html"
 
@@ -211,7 +206,7 @@ class PasswordResetRequestView(generic.FormView):
     with valid data.
     """
 
-    form_class = PasswordResetRequestForm
+    form_class = forms.PasswordResetRequestForm
     template_name = "accounts/recovery/password_reset_request.html"
     success_url = reverse_lazy("hidp_accounts:password_reset_email_sent")
     password_reset_view = "hidp_accounts:password_reset"  # noqa: S105 (not a password)
@@ -238,7 +233,7 @@ class PasswordResetView(auth_views.PasswordResetConfirmView):
     Display the password reset form and handle the password reset action.
     """
 
-    form_class = PasswordResetForm
+    form_class = forms.PasswordResetForm
     template_name = "accounts/recovery/password_reset.html"
     success_url = reverse_lazy("hidp_accounts:password_reset_complete")
 

--- a/packages/hidp/tests/unit_tests/test_accounts/test_forms.py
+++ b/packages/hidp/tests/unit_tests/test_accounts/test_forms.py
@@ -1,6 +1,6 @@
 from django.test import TestCase, override_settings
 
-from hidp.accounts.forms import AuthenticationForm, UserCreationForm
+from hidp.accounts import forms
 from hidp.test.factories import user_factories
 
 
@@ -14,14 +14,14 @@ class TestAuthenticationForm(TestCase):
         cls.user = user_factories.UserFactory()
 
     def test_is_valid(self):
-        form = AuthenticationForm(
+        form = forms.AuthenticationForm(
             data={"username": self.user.email, "password": "P@ssw0rd!"}
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(form.get_user(), self.user)
 
     def test_is_invalid(self):
-        form = AuthenticationForm(
+        form = forms.AuthenticationForm(
             data={"username": self.user.email, "password": "wrong"}
         )
         self.assertFalse(form.is_valid())
@@ -40,7 +40,7 @@ class TestAuthenticationForm(TestCase):
         self.user.save()
 
         with self.subTest("Default backend"):
-            form = AuthenticationForm(
+            form = forms.AuthenticationForm(
                 data={"username": self.user.email, "password": "P@ssw0rd!"}
             )
             self.assertFalse(form.is_valid())
@@ -63,7 +63,7 @@ class TestAuthenticationForm(TestCase):
                 ]
             ),
         ):
-            form = AuthenticationForm(
+            form = forms.AuthenticationForm(
                 data={"username": self.user.email, "password": "P@ssw0rd!"}
             )
             self.assertFalse(form.is_valid())
@@ -75,7 +75,7 @@ class TestAuthenticationForm(TestCase):
 class TestOptionalTOSUserCreationFormForm(TestCase):
     @classmethod
     def setUpTestData(cls):
-        class NoTOSUserCreationForm(UserCreationForm):
+        class NoTOSUserCreationForm(forms.UserCreationForm):
             """
             UserCreationForm without the agreed_to_tos field.
             """


### PR DESCRIPTION
Noticed this when adding more forms for the account activation flow. This keeps the import the same, no matter how many forms we add.