### PR TITLE
HIDP-81 Add documentation related to rate limits and security considerations

### DIFF
--- a/packages/hidp/docs/conf.py
+++ b/packages/hidp/docs/conf.py
@@ -21,6 +21,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autodoc_mock_imports = ["django"]
 
+myst_heading_anchors = 3
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/packages/hidp/docs/index.md
+++ b/packages/hidp/docs/index.md
@@ -11,6 +11,7 @@ This is Leukeleu's Headless Identity Provider
 :maxdepth: 2
 installation
 user-model
+rate-limiting
 :::
 
 # Indices and tables

--- a/packages/hidp/docs/rate-limiting.md
+++ b/packages/hidp/docs/rate-limiting.md
@@ -1,0 +1,64 @@
+# Rate limiting
+HIdP uses the [django-ratelimit](https://django-ratelimit.readthedocs.io/en/stable/index.html)
+package to apply rate limiting on key pages, such as the login and registration pages,
+to prevent DDoS and brute force attacks.
+
+## Default rate limits
+The default rate limits are:
+
+- 10 requests per second
+- 30 requests per minute
+
+The following rate limit is added for views that need to be more strict:
+
+- 100 requests per 15 minutes
+
+The time component of each rate limit also serves as the 'lockout period'. Meaning
+requests from the same IP will be blocked for this duration when they exceed the limit.
+
+HIdP may be used by applications with many users sharing the same IP, such as schools
+or corporate networks. Since rate limiting is based on IP, lowering the default limits
+could be disruptive. However, you can adjust the rate limits to be more strict
+if needed.
+
+## Adding your own rate limits
+You can add additional rate limits to views like this:
+
+```python
+from django.utils.decorators import method_decorator
+
+from django_ratelimit.decorators import ratelimit
+
+from hidp.accounts.views import LoginView
+
+@method_decorator(ratelimit(key='ip', rate='1/m', method=ratelimit.UNSAFE), name='dispatch')
+class MyCustomLoginView(LoginView):
+    def get(self, request):
+        ...
+
+```
+
+:::{note}
+For more examples, see [django-ratelimit documentation](https://django-ratelimit.readthedocs.io/en/stable/usage.html).
+:::
+
+## Security considerations
+HIdP uses `ip` as the [ratelimit key](https://django-ratelimit.readthedocs.io/en/stable/keys.html#ratelimit-keys)
+for most rate limits. To ensure safety, it is crucial to that `REMOTE_ADDR` is resolved
+correctly, especially when Django is behind a load balancer or reverse proxy.
+
+If `REMOTE_ADDR` is not resolved correctly, the rate limits may be applied to all
+requests indiscriminately, regardless of the actual IP address, or could be
+bypassed entirely.
+
+Without a proper cache setup the rate limits will not be applied correctly either, see [Cache](project:installation.md#cache) for more information.
+
+:::{note}
+For more information, see [django-ratelimit security considerations](https://django-ratelimit.readthedocs.io/en/stable/security.html#security-considerations).
+:::
+
+When configured correctly, HIdP's rate limits offer basic protection against brute
+force attacks and other bot behavior. However, while rate limits help mitigate some
+risks, they are not a comprehensive security solution. Consider combining rate limits
+with other security measures, such as CAPTCHAs, and continuously monitoring for
+potential threats.


### PR DESCRIPTION
First sort of draft for documentation of the rate limiting, explaining what rate limits there are and what the users of HIdP should take into account.

I figured that because HIdP is open source, we don't have to be secretive about the exact rate limits, because they can figure it out through the source code anyway

Preview:
<img width="796" alt="Screenshot 2024-08-13 at 14 40 12" src="https://github.com/user-attachments/assets/31bc1fb0-0e16-4dcd-9051-e23019af6f39">
<img width="783" alt="Screenshot 2024-08-13 at 14 40 19" src="https://github.com/user-attachments/assets/3f37e99c-a0a1-44cb-8e8b-1d26faa61b73">

