### PR TITLE
Remove the usable_password field

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -39,6 +39,8 @@ class UserCreationForm(auth_forms.UserCreationForm):
         ),
         required=True,
     )
+    # Remove the option to create an account with an unusable password.
+    usable_password = None
 
     class Meta(auth_forms.UserCreationForm.Meta):
         model = UserModel


### PR DESCRIPTION
Django 5.1 adds the option to sign up with an unusable password, HIdP does not need this

Removes this bit of the form:

<img width="1373" alt="Screenshot 2024-08-12 at 16 10 54" src="https://github.com/user-attachments/assets/95dc6d06-011c-4f81-9934-5b89f499d7d9">
