### PR TITLE
HIDP-134 Add checkbox to login view when user is rate limited

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -405,3 +405,22 @@ class PasswordResetForm(auth_forms.SetPasswordForm):
             The user with the new password set.
         """
         return super().save(commit=commit)
+
+
+class RateLimitedAuthenticationForm(AuthenticationForm):
+    """
+    Authentication form that is used when a user is rate limited.
+    This form includes a simple "I am not a robot" checkbox to demonstrate
+    how additional protection can be added to an authentication form.
+
+    It is recommended to replace this form with a more robust implementation
+    that provides stronger protection against automated attacks.
+    """
+
+    i_am_not_a_robot = forms.BooleanField(
+        label=_("I am not a robot"),
+        required=True,
+        error_messages={
+            "required": _("Please confirm that you are not a robot."),
+        },
+    )

--- a/packages/hidp/hidp/templates/hidp/accounts/login.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/login.html
@@ -29,6 +29,14 @@
 
   <h1>{% translate 'Log in with username and password' %}</h1>
 
+  {% if request.limited %}
+  <p>
+    {% blocktranslate %}
+    Your login attempt has been rate limited. Additional security measures are in place for your protection.
+    {% endblocktranslate %}
+  </p>
+  {% endif %}
+
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}


### PR DESCRIPTION
We rate limit the login view based on the posted username, but that is an attack vector, as threat actors can do many login attempts in order for a single user to be locked out. The `django-ratelimit` documentation (and in ours) recommends to implement some sort of captcha to protect against these kind of attacks.

However, we prefer not to maintain extra code or a dependency for this, but we want to allow users of HIdP to easily be able to implement their own security measures for this. 

This PR adds a new `RateLimitedAuthenticationForm` that adds a single checkbox to confirm the user is not a robot. This form will be used when the user gets rate limited and allows the user to login (because the `block` is set to `False`)

<img width="559" alt="Screenshot 2024-08-21 at 17 59 43" src="https://github.com/user-attachments/assets/89a1d415-fc52-4a1d-9f39-f781efba5168">

TODO:
- [x] write a test