### PR TITLE
HIDP-115 password reset redux

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -1,13 +1,8 @@
-from urllib.parse import urljoin
-
 from django import forms
 from django.contrib.auth import forms as auth_forms
 from django.contrib.auth import get_user_model
-from django.contrib.auth.tokens import default_token_generator
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse_lazy
 from django.utils import timezone
-from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
 from django.utils.safestring import mark_safe
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
@@ -177,201 +172,32 @@ class AuthenticationForm(auth_forms.AuthenticationForm):
         return super().confirm_login_allowed(user)
 
 
-class PasswordResetRequestForm(auth_forms.PasswordResetForm):
+class PasswordResetRequestForm(forms.Form):
     """
     Start the password reset process for a user, by requesting a
     password reset email.
 
-    The user is asked to enter their email address, and a password reset email
-    is sent to the user. The email contains a link to a page that allows the
-    user to enter a new password.
-
-    Attributes:
-        subject_template_name:
-            Template to use for the email subject.
-        email_template_name:
-            Template to use for the email body.
-        html_email_template_name:
-            The name of the template to use for the HTML email body.
-            Optional, defaults to `None`.
-        password_reset_token_generator:
-            Token generator to use for the password reset token.
-            Defaults to `django.contrib.auth.tokens.default_token_generator`.
     """
 
-    subject_template_name = "hidp/accounts/recovery/email/password_reset_subject.txt"
-    email_template_name = "hidp/accounts/recovery/email/password_reset_body.txt"
-    html_email_template_name = None
-    password_reset_token_generator = default_token_generator
+    email = forms.EmailField(
+        label=_("Email"),
+        max_length=254,
+        widget=forms.EmailInput(attrs={"autocomplete": "email"}),
+    )
 
-    def get_users(self, email):
+    def get_user(self):
         """
-        Return all **active** users with the given email address (case-insensitive),
-        that have a usable password. Should be one user at most, if the correct
-        user model is used.
+        Given an email, return the user who should receive a reset.
 
-        Inactive users, and users with unusable passwords, are not allowed to
-        perform a password reset.
-
-        Args:
-            email:
-                The email address to use for the user lookup.
-
-        Returns:
-            A generator that yields all active users, that have a usable password,
-            with the given email address (case-insensitive).
+        Returns None if no user is found, or the user is not allowed
+        to reset their password (e.g. inactive, no password).
         """
-        return super().get_users(email)
-
-    def send_mail(self, *, to_email, context, from_email=None):
-        """
-        Send a password reset email to the user.
-
-        Called by the `save` method to send the email to the user.
-        The `save` method is also responsible for providing the context data
-        required to build a functional password reset email.
-
-        Args:
-            to_email:
-                The email address to send the email to.
-            context:
-                Context data for email templates, used for the
-                subject and body templates.
-            from_email:
-                Email address to use as the sender of the email.
-                Optional, uses the `DEFAULT_FROM_EMAIL` setting if not provided.
-
-        """
-        super().send_mail(
-            from_email=from_email,
-            to_email=to_email,
-            subject_template_name=self.subject_template_name,
-            email_template_name=self.email_template_name,
-            html_email_template_name=self.html_email_template_name,
-            context=context,
-        )
-
-    def get_password_reset_token(self, user):
-        """
-        Return the password reset token for the given user.
-
-        The token is used to create a link to the password reset page.
-
-        Args:
-            user:
-                User that requested the password reset.
-
-        Returns:
-            A token for the password reset page.
-        """
-        return self.password_reset_token_generator.make_token(user)
-
-    def get_password_reset_url(self, *, user, base_url, password_reset_view):
-        """
-        Return the URL to the password reset page for the given user.
-
-        Args:
-            user:
-                User that requested the password reset.
-            base_url:
-                Used to make an absolute URL to the password reset page.
-                Use `request.build_absolute_uri("/")` to populate this value if the
-                request object is available.
-            password_reset_view:
-                Name that reverses to the password reset view.
-
-        Returns:
-            An absolute URL to the password reset page for the given user.
-        """
-        return urljoin(
-            base_url,
-            reverse(
-                password_reset_view,
-                kwargs={
-                    "uidb64": urlsafe_base64_encode(force_bytes(user.pk)),
-                    "token": self.get_password_reset_token(user),
-                },
-            ),
-        )
-
-    def get_email_template_context(
-        self,
-        *,
-        user,
-        base_url,
-        password_reset_view,
-        extra_email_context=None,
-    ):
-        """
-        Return the context data for the password reset email.
-
-        Args:
-            user:
-                User that requested the password reset.
-            base_url:
-                Used to make an absolute URL to the password reset page in the email.
-                Use `request.build_absolute_uri("/")` to populate this value if the
-                request object is available.
-            password_reset_view:
-                Name that reverses to the password reset view.
-            extra_email_context:
-                Extra context data to add to the email context.
-
-        Returns:
-            A dictionary with the following keys:
-
-            * `email`: The email address of the user.
-            * `user`: The user that requested the password reset.
-            * `password_reset_url`: The URL to the password reset page.
-            * Any additional data present in `extra_email_context`.
-        """
-        email_field_name = UserModel.get_email_field_name()
-        user_email = getattr(user, email_field_name)
-        return {
-            "email": user_email,
-            "user": user,
-            "password_reset_url": self.get_password_reset_url(
-                user=user, base_url=base_url, password_reset_view=password_reset_view
-            ),
-        } | (extra_email_context or {})
-
-    def save(
-        self,
-        *,
-        base_url,
-        password_reset_view,
-        from_email=None,
-        extra_email_context=None,
-    ):
-        """
-        Each user that matches the entered email address is sent a password
-        reset email.
-
-        Args:
-            from_email:
-                Email address to use as the sender of the email.
-                Optional, uses the `DEFAULT_FROM_EMAIL` setting if not provided.
-            base_url:
-                Used to make an absolute URL to the password reset page in the email.
-                Use `request.build_absolute_uri("/")` to populate this value if the
-                request object is available.
-            password_reset_view:
-                Name that reverses to the password reset view.
-            extra_email_context:
-                Extra context data to add to the email context.
-        """
-        for user in self.get_users(self.cleaned_data["email"]):
-            context = self.get_email_template_context(
-                user=user,
-                base_url=base_url,
-                password_reset_view=password_reset_view,
-                extra_email_context=extra_email_context,
-            )
-            self.send_mail(
-                to_email=context["email"],
-                context=context,
-                from_email=from_email,
-            )
+        user = UserModel.objects.filter(
+            email__iexact=self.cleaned_data["email"], is_active=True
+        ).first()
+        if user and user.has_usable_password():
+            return user
+        return None
 
 
 class PasswordResetForm(auth_forms.SetPasswordForm):

--- a/packages/hidp/hidp/accounts/mailer.py
+++ b/packages/hidp/hidp/accounts/mailer.py
@@ -1,8 +1,11 @@
 from urllib.parse import urljoin
 
+from django.contrib.auth.tokens import default_token_generator
 from django.core.mail import EmailMultiAlternatives
 from django.template import loader
 from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
 from . import email_verification
 
@@ -131,6 +134,49 @@ class AccountExistsMailer(BaseMailer):
                     self.base_url, reverse("hidp_accounts:password_reset_request")
                 ),
             }
+        )
+
+    def get_recipients(self):
+        return [self.user.email]
+
+
+class PasswordResetRequestMailer(BaseMailer):
+    subject_template_name = "hidp/accounts/recovery/email/password_reset_subject.txt"
+    email_template_name = "hidp/accounts/recovery/email/password_reset_body.txt"
+    token_generator = default_token_generator
+
+    def __init__(self, user, *, base_url):
+        super().__init__(base_url=base_url)
+        self.user = user
+
+    def get_password_reset_url(self):
+        """
+        Return the URL to the password reset page for the given user.
+
+        Returns:
+            An absolute URL to the password reset page for the given user.
+        """
+        return urljoin(
+            self.base_url,
+            reverse(
+                "hidp_accounts:password_reset",
+                kwargs={
+                    "uidb64": urlsafe_base64_encode(force_bytes(self.user.pk)),
+                    "token": self.token_generator.make_token(self.user),
+                },
+            ),
+        )
+
+    def get_context(self, extra_context=None):
+        email_field_name = self.user.__class__.get_email_field_name()
+        user_email = getattr(self.user, email_field_name)
+        return super().get_context(
+            {
+                "email": user_email,
+                "user": self.user,
+                "password_reset_url": self.get_password_reset_url(),
+            }
+            | (extra_context or {})
         )
 
     def get_recipients(self):

--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -419,20 +419,21 @@ class PasswordResetRequestView(generic.FormView):
     Display the password reset request form and handle the password
     reset request action.
 
-    Redirects to the password reset sent view if the form is submitted
-    with valid data.
+    Sends the password reset email and redirects to the password reset
+    sent view if the form is submitted with valid data.
     """
 
     form_class = forms.PasswordResetRequestForm
     template_name = "hidp/accounts/recovery/password_reset_request.html"
     success_url = reverse_lazy("hidp_accounts:password_reset_email_sent")
-    password_reset_view = "hidp_accounts:password_reset"  # noqa: S105 (not a password)
+    password_reset_request_mailer = mailer.PasswordResetRequestMailer
 
     def form_valid(self, form):
-        form.save(
-            base_url=self.request.build_absolute_uri("/"),
-            password_reset_view=self.password_reset_view,
-        )
+        if user := form.get_user():
+            self.password_reset_request_mailer(
+                user=user,
+                base_url=self.request.build_absolute_uri("/"),
+            ).send()
         return super().form_valid(form)
 
 

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_recovery.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_recovery.py
@@ -4,7 +4,7 @@ from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
 
-from hidp.accounts import forms
+from hidp.accounts import forms, mailer
 from hidp.test.factories import user_factories
 
 
@@ -82,11 +82,9 @@ class TestPasswordResetFlow(TestCase):
         self.assertEqual(message.to, [self.user.email])
         self.assertEqual(message.subject, "Password reset request")
         self.assertIn(
-            forms.PasswordResetRequestForm().get_password_reset_url(
-                user=self.user,
-                base_url="http://testserver",
-                password_reset_view="hidp_accounts:password_reset",
-            ),
+            mailer.PasswordResetRequestMailer(
+                user=self.user, base_url="http://testserver"
+            ).get_password_reset_url(),
             message.body,
         )
         self.assertRedirects(
@@ -100,11 +98,10 @@ class TestPasswordResetFlow(TestCase):
 
     def test_get_password_reset_url(self):
         """Render the password reset form."""
-        password_reset_url = forms.PasswordResetRequestForm().get_password_reset_url(
+        password_reset_url = mailer.PasswordResetRequestMailer(
             user=self.user,
             base_url="https://testserver",
-            password_reset_view="hidp_accounts:password_reset",
-        )
+        ).get_password_reset_url()
         response = self.client.get(password_reset_url, follow=True)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertTemplateUsed(response, "hidp/accounts/recovery/password_reset.html")
@@ -116,11 +113,10 @@ class TestPasswordResetFlow(TestCase):
 
     def test_post_password_reset_url(self):
         """Reset the user's password."""
-        password_reset_url = forms.PasswordResetRequestForm().get_password_reset_url(
+        password_reset_url = mailer.PasswordResetRequestMailer(
             user=self.user,
             base_url="https://testserver",
-            password_reset_view="hidp_accounts:password_reset",
-        )
+        ).get_password_reset_url()
         # Need to get the password reset form first to populate a session value.
         response = self.client.get(
             password_reset_url,


### PR DESCRIPTION
Refactors the password reset request form to only validate the email and get the related user. Sending the mail is now done in the view, and uses the mailer system.

This makes this flow much more similar to the registration / confirmation flow, making things much more DRY (and easier to understand imho).