### PR TITLE
HIDP-135 Add blocks for style and script injection

### DIFF
--- a/packages/hidp/docs/templates.md
+++ b/packages/hidp/docs/templates.md
@@ -23,8 +23,13 @@ HTML boilerplate for each page. Override this template to load custom CSS, scrip
 and set up a base layout.
 
 This template defines two blocks that all other templates depend on:
-- `title` - inside the HTML title tag
-- `body` - inside the HTML body tag
+- `title` - inside the HTML title tag.
+- `body` - inside the HTML body tag.
+
+This template also defines two blocks that you can extend to inject extra styles and/or
+scripts:
+- `extra_head` - inside the HTML head tag, after the `title` tag.
+- `extra_body` - inside the HTML body tag, below the `body` block.
 
 ## **accounts**
 

--- a/packages/hidp/hidp/templates/hidp/base.html
+++ b/packages/hidp/hidp/templates/hidp/base.html
@@ -3,9 +3,13 @@
 <head>
   <meta charset="utf-8">
   <title>{% block title %}{% endblock %}</title>
+  {% block extra_head %}
+  {% endblock %}
 </head>
 <body>
 {% block body %}
+{% endblock %}
+{% block extra_body %}
 {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Other projects:

- Django admin has `extrastyle`, `extrahead` and `extrabody`
- Django allauth has `extra_head` and `extra_body`
- Our Docker compose setup has `extra_head` and `extra_js`

I opted for a combination: `extra_head` and `extra_body`, as those are the actual places where you add something. I like the underscores better than the django admin way, as they are actually separate words in English.