### PR TITLE
Rename root app config

### DIFF
--- a/packages/hidp/hidp/apps.py
+++ b/packages/hidp/hidp/apps.py
@@ -7,5 +7,5 @@ class HidpChecksMixin:
         from .config import checks  # noqa: F401, PLC0415
 
 
-class AccountsConfig(HidpChecksMixin, AppConfig):
+class HidpConfig(HidpChecksMixin, AppConfig):
     name = "hidp"


### PR DESCRIPTION
Noticed this while debugging an issue while integrating HIdP. This is unrelated to the issue, but it doesn't hurt to clean this up.