### PR TITLE
Allow clients to override the OIDC request scope

### DIFF
--- a/packages/hidp/hidp/federated/oidc/authorization_code_flow.py
+++ b/packages/hidp/hidp/federated/oidc/authorization_code_flow.py
@@ -226,6 +226,7 @@ def prepare_authentication_request(
         client_id=client.client_id,
         redirect_uri=_build_absolute_uri(request, client, callback_url),
         state=state_key,
+        scope=client.scope,
         **extra_params,
     )
 

--- a/packages/hidp/hidp/federated/providers/base.py
+++ b/packages/hidp/hidp/federated/providers/base.py
@@ -100,6 +100,9 @@ class OIDCClient:
     client_id = None
     client_secret = None
     callback_base_url = None
+    # Note: Most providers should support these scopes. If not, (e.g. Facebook) override
+    #       the attribute in the subclass.
+    scope = "openid email profile"
 
     def __init__(self, *, client_id, client_secret=None, callback_base_url=None):
         """


### PR DESCRIPTION
Based on https://github.com/leukeleu/leukeleu-hidp/pull/156 for no other reason than that it makes it easier to develop at-accounts.