### PR TITLE
Add normalize_userinfo to OIDCClient

### DIFF
--- a/packages/hidp/hidp/federated/oidc/authorization_code_flow.py
+++ b/packages/hidp/hidp/federated/oidc/authorization_code_flow.py
@@ -581,7 +581,7 @@ def get_user_info(*, client, access_token, claims):
     # https://openid.net/specs/openid-connect-basic-1_0.html#UserInfoResponse
     try:
         # The UserInfo Claims MUST be returned as the members of a JSON object.
-        user_info = response.json()
+        user_info = client.normalize_userinfo(userinfo=response.json())
     except json.JSONDecodeError:
         raise OIDCError(
             f"Failed to parse user information from {client.provider_key!r}"

--- a/packages/hidp/hidp/federated/providers/base.py
+++ b/packages/hidp/hidp/federated/providers/base.py
@@ -200,3 +200,26 @@ class OIDCClient:
         # for each tenant. This method allows to return the expected
         # issuer based on the claims.
         return self.issuer
+
+    @staticmethod
+    def normalize_userinfo(*, userinfo):
+        """
+        Normalize the data from the userinfo endpoint to the standard format.
+
+        This method should only be overridden if absolutely necessary.
+
+        Arguments:
+            userinfo (``dict``):
+                The raw data from the userinfo endpoint.
+
+        Returns:
+            ``dict``:
+                The normalized userinfo data.
+        """
+        # Some providers return user information in a different format.
+        #
+        # For example, Facebook uses 'id' instead of 'sub' and 'first_name' &
+        # 'last_name' instead of 'given_name' & 'family_name'.
+        #
+        # Remap the keys to the standard claims if necessary.
+        return userinfo


### PR DESCRIPTION
This makes it possible to correct non-compliant responses from the user info endpoint.

Based on https://github.com/leukeleu/leukeleu-hidp/pull/158 for no other reason than that it makes it easier to develop at-accounts.