### PR TITLE
Support permanently changing the max. days for remove_stale_unverified_accounts

### DIFF
--- a/packages/hidp/docs/management-commands.md
+++ b/packages/hidp/docs/management-commands.md
@@ -30,9 +30,13 @@ For more information, please see [cleartokens](https://django-oauth-toolkit.read
 
 ## remove_stale_unverified_accounts
 The ``remove_stale_unverified_accounts`` management command removes accounts that have
-not been verified within a specific number of days after creation.
+not been verified within a specific number of days after creation (90 days by default).
 
 The following optional flags are available:
 - ``--days`` - Maximum number of days an account is allowed to be unverified: defaults to 90.
 - ``--dry-run`` - If `True`, returns the number of accounts that would be removed,
 without performing the removal. Defaults to `False`.
+
+To permanently change the default value of the `--days` flag, you can override the command
+in your project by subclassing `hidp.accounts.management.commands.remove_stale_unverified_accounts.Command`
+and setting the `DEFAULT_MAX_DAYS` class attribute to the desired value.

--- a/packages/hidp/hidp/accounts/management/commands/remove_stale_unverified_accounts.py
+++ b/packages/hidp/hidp/accounts/management/commands/remove_stale_unverified_accounts.py
@@ -4,19 +4,20 @@ from ...email_verification import remove_stale_unverified_accounts
 
 
 class Command(BaseCommand):
+    DEFAULT_MAX_DAYS = 90
     help = (
         "Remove accounts that have not been verified within"
         " a specific number of days after creation"
     )
 
-    def add_arguments(self, parser):  # noqa: PLR6301
+    def add_arguments(self, parser):
         parser.add_argument(
             "--days",
             type=int,
-            default=90,
+            default=self.DEFAULT_MAX_DAYS,
             help=(
-                "Maximum number of days an account is allowed to be unverified:"
-                " defaults to 90."
+                f"Maximum number of days an account is allowed to be unverified:"
+                f" defaults to {self.DEFAULT_MAX_DAYS}."
             ),
         )
 


### PR DESCRIPTION
Just making it more convenient for users to change this (without adding settings to HIdP).