### PR TITLE
Loosen dependency pins where appropriate

### DIFF
--- a/packages/hidp/requirements.txt
+++ b/packages/hidp/requirements.txt
@@ -1,4 +1,4 @@
 Django>=4.2,<6
-django-ratelimit~=4.1.0
-jwcrypto~=1.5.6
-requests~=2.32.3
+django-ratelimit>=4.1.0,<5
+jwcrypto>=1.5,<2
+requests>=2.32,<3

--- a/packages/hidp/requirements_oidc_provider.txt
+++ b/packages/hidp/requirements_oidc_provider.txt
@@ -1,2 +1,2 @@
-django-oauth-toolkit~=3.0.1
-djangorestframework~=3.15.2
+django-oauth-toolkit>=3.0.1,<3.1
+djangorestframework>=3.15.2,<3.16


### PR DESCRIPTION
Since HIdP is a library it shouldn't be too picky about which versions of its dependencies are installed (to avoid issues with other packages and/or the project it is installed in).