### PR TITLE
Bump Python for development and CI

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install system packages (gettext)
       run: |

--- a/project/Dockerfile
+++ b/project/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 
 # Create the project image
 FROM python:$PYTHON_VERSION


### PR DESCRIPTION
I think we *technically* need to have a test matrix to test against multiple Python and Django versions so we can make some compatibility claims. For now I'm just bumping Python to see what happens (the minimum required python remains at 3.11).