### PR TITLE
Use postgres db in CI

### DIFF
--- a/packages/hidp/tests/test_settings.py
+++ b/packages/hidp/tests/test_settings.py
@@ -101,7 +101,7 @@ SECRET_KEY = "secret-key-only-for-testing"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "test_hidp",
+        "NAME": "postgres" if "CI" in os.environ else "test_hidp",
         "USER": "postgres",
         "PASSWORD": "postgres",
         "HOST": "localhost" if "CI" in os.environ else "postgres",


### PR DESCRIPTION
Need to use an existing database in CI otherwise the migration consistency cannot be checked. This isn't fatal but results in a warning that can be avoided this way.