### PR TITLE
Install hiredis as an extra instead of seperately

### DIFF
--- a/project/requirements_local.txt
+++ b/project/requirements_local.txt
@@ -2,5 +2,4 @@
 -e ../packages/hidp-pycqa
 
 # Redis
-hiredis>=2.3,<3.1
-redis~=5.1.0
+redis[hiredis]~=5.1.0


### PR DESCRIPTION
This should guarantee compatibility with the redis package