### PR TITLE
HIDP-181 post invalid tokens

### DIFF
--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -144,6 +144,50 @@ class BaseTokenMixin:
         )
         return HttpResponseRedirect(redirect_url, status=308)
 
+    def get_context_data(self, **kwargs):
+        context = {
+            "validlink": self.validlink,
+        }
+        return super().get_context_data() | context | kwargs
+
+    def validate_token_data(self, token_data):  # noqa: PLR6301 (no-self-use)
+        """
+        Validate the token data.
+
+        Override this method to add additional validation checks.
+
+        Returns:
+            bool:
+                True if the token data is valid, otherwise False.
+        """
+        return token_data is not None
+
+    def dispatch(self, request, *, token):
+        """
+        Handle tokens in URLs.
+
+        Makes sure the token is removed from the URL and stored in
+        the session.
+
+        Sets the `validlink` attribute to whether the token is valid.
+
+        If `validlink` is False, the `get` method will be called
+        irrespective of the HTTP method used.
+        """
+        response = self._remove_token_from_url(token)
+        if response:
+            return response
+
+        token = self.request.session.get(self.token_session_key)
+        token_data = self.token_generator.check_token(token) if token else None
+        self.validlink = self.validate_token_data(token_data)
+
+        if not self.validlink:
+            # Invalid token, handle it in the `get` method.
+            return self.get(request, token=token)
+
+        return super().dispatch(request, token=token)
+
 
 class EmailTokenMixin(BaseTokenMixin):
     """Mixin to handle email verification tokens in URLs."""
@@ -159,7 +203,7 @@ class EmailTokenMixin(BaseTokenMixin):
         """
         return UserModel.objects.annotate(email_hash=MD5("email"))
 
-    def _get_user_from_token(self):
+    def _get_user_from_token(self, email_hash):
         """
         Find the user associated with the token in the session.
 
@@ -167,30 +211,26 @@ class EmailTokenMixin(BaseTokenMixin):
             UserModel | None:
                 The user if the token is valid, otherwise None.
         """
-        token = self.request.session.get(self.token_session_key)
-        if token is None:
-            return None
-        email_hash = self.token_generator.check_token(token)
         # Find the user by the hash of their email address
         return self._get_user_queryset().filter(email_hash=email_hash).first()
 
-    def dispatch(self, request, *, token):
+    def validate_token_data(self, token_data):
         """
-        Handle email verification tokens in URLs.
-
-        Makes sure the token is removed from the URL and stored in
-        the session.
+        Validate the token data.
 
         Sets the `user` attribute to the user found by the token,
-        and the `validlink` attribute to whether the token is valid
-        (i.e. it resolves to a user).
+        or `None` if the token is invalid.
+
+        Returns:
+            bool:
+                True if the token data is valid, otherwise False.
         """
-        response = self._remove_token_from_url(token)
-        if response:
-            return response
-        self.user = self._get_user_from_token()
-        self.validlink = self.user is not None
-        return super().dispatch(request, token=token)
+        if super().validate_token_data(token_data):
+            self.user = self._get_user_from_token(token_data)
+            return self.user is not None
+        else:
+            self.user = None
+            return False
 
 
 class EmailChangeTokenMixin(BaseTokenMixin):
@@ -216,35 +256,30 @@ class EmailChangeTokenMixin(BaseTokenMixin):
             return None
         return email_change_request
 
-    def _check_token(self, token):
-        token = self.request.session.get(self.token_session_key)
-        if token is None:
-            return None
-        return self.token_generator.check_token(token)
-
-    def dispatch(self, request, *, token):
+    def validate_token_data(self, token_data):
         """
-        Handle email change tokens in URLs.
-
-        Makes sure the token is removed from the URL and stored in
-        the session.
+        Validate the token data.
 
         Sets the `email_change_request` attribute to the email change request
-        found by the token, and the `validlink` attribute to whether the token
-        is valid (i.e. it resolves to an email change request).
+        found by the token, or `None` if the token is invalid.
+
+        Sets the `recipient` attribute to the recipient of the token,
+        or `None` if the token is invalid.
+
+        Returns:
+            bool:
+                True if the token data is valid, otherwise False.
         """
-        response = self._remove_token_from_url(token)
-        if response:
-            return response
-        token_object = self._check_token(token)
-        self.email_change_request = (
-            self._get_email_change_request_from_token_object(token_object)
-            if token_object
-            else None
-        )
-        self.recipient = token_object["recipient"] if token_object else None
-        self.validlink = self.email_change_request is not None
-        return super().dispatch(request, token=token)
+        if super().validate_token_data(token_data):
+            self.email_change_request = (
+                self._get_email_change_request_from_token_object(token_data)
+            )
+            self.recipient = token_data["recipient"]
+            return self.email_change_request is not None
+        else:
+            self.email_change_request = None
+            self.recipient = None
+            return False
 
 
 @method_decorator(hidp_csp_protection, name="dispatch")
@@ -265,12 +300,6 @@ class EmailVerificationRequiredView(
     token_generator = tokens.email_verification_request_token_generator
     verification_mailer = mailers.EmailVerificationMailer
     token_session_key = "_email_verification_request_token"  # noqa: S105 (not a password)
-
-    def get_context_data(self, **kwargs):
-        context = {
-            "validlink": self.validlink,
-        }
-        return super().get_context_data() | context | kwargs
 
     def send_email(self):
         """Send the email verification email."""
@@ -316,12 +345,6 @@ class EmailVerificationView(
 
     def _get_user_queryset(self):
         return super()._get_user_queryset().email_unverified().filter(is_active=True)
-
-    def get_context_data(self, **kwargs):
-        context = {
-            "validlink": self.validlink,
-        }
-        return super().get_context_data() | context | kwargs
 
     def get_object(self):
         return self.user  # The user from the token
@@ -919,11 +942,8 @@ class EmailChangeConfirmView(
     token_session_key = "_email_change_request_token"  # noqa: S105 (not a password)
 
     def get_context_data(self, **kwargs):
-        context = {
-            "validlink": self.validlink,
-        }
         if self.validlink:
-            context |= {
+            context = {
                 "recipient": self.recipient,
                 "already_confirmed_for_this_email": getattr(
                     self.email_change_request, f"confirmed_by_{self.recipient}"
@@ -931,6 +951,8 @@ class EmailChangeConfirmView(
                 "current_email": self.email_change_request.current_email,
                 "proposed_email": self.email_change_request.proposed_email,
             }
+        else:
+            context = {}
         return super().get_context_data() | context | kwargs
 
     def get_form_kwargs(self):

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
@@ -253,6 +253,24 @@ class TestEmailChangeConfirm(TestCase):
             response.content.decode(),
         )
 
+    def test_no_token_in_session(self):
+        """Placeholder token, no token in session."""
+        response = self.client.get(
+            reverse(
+                "hidp_accounts:email_change_confirm",
+                kwargs={"token": "email-change"},
+            ),
+            follow=True,
+        )
+        self.assertTemplateUsed(
+            response, "hidp/accounts/management/email_change_confirm.html"
+        )
+        self.assertInHTML(
+            "The link you followed is invalid."
+            " It may have expired or been used already.",
+            response.content.decode(),
+        )
+
     def test_valid_token_wrong_user(self):
         self.client.force_login(user_factories.UserFactory())
         response = self.client.get(self.current_email_url, follow=True)
@@ -363,6 +381,24 @@ class TestEmailChangeConfirm(TestCase):
         )
         self.assertTrue(email_change_request.exists())
         self.assertTrue(email_change_request.first().is_complete())
+
+    def test_post_invalid_token(self):
+        response = self.client.post(
+            reverse(
+                "hidp_accounts:email_change_confirm",
+                kwargs={"token": "invalid"},
+            ),
+            {"allow_change": "on"},
+            follow=True,
+        )
+        self.assertTemplateUsed(
+            response, "hidp/accounts/management/email_change_confirm.html"
+        )
+        self.assertInHTML(
+            "The link you followed is invalid."
+            " It may have expired or been used already.",
+            response.content.decode(),
+        )
 
     def test_post_proposed_email_already_exists(self):
         # Should only happen if an account was created with the proposed email

--- a/packages/hidp/tests/smoke_tests/test_federated/test_views.py
+++ b/packages/hidp/tests/smoke_tests/test_federated/test_views.py
@@ -338,11 +338,12 @@ class OIDCTokenDataTestMixin:
     def setUp(self):
         configure_oidc_clients(ExampleOIDCClient(client_id="test"))
 
-    def _assert_invalid_token(self, *, token=None):
+    def _assert_invalid_token(self, *, token=None, method="get"):
+        request_method = getattr(self.client, method)
         response = (
-            self.client.get(self.url, follow=True)
+            request_method(self.url, follow=True)
             if token is None
-            else self.client.get(self.url, {"token": token}, follow=True)
+            else request_method(self.url, {"token": token}, follow=True)
         )
         self.assertInHTML(
             "Expired or invalid token. Please try again.",
@@ -375,6 +376,9 @@ class OIDCTokenDataTestMixin:
 
     def test_invalid_token(self):
         self._assert_invalid_token(token="invalid")
+
+    def test_post_invalid_token(self):
+        self._assert_invalid_token(token="invalid", method="post")
 
     def test_valid_token_missing_session_data(self):
         # Do not save the session to mimic an expired session or hijacked token


### PR DESCRIPTION
Move more shared logic to `BaseTokenMixin` and let it handle the `invalidlink` case regardless of request method.

With this refactor `post` requests using invalid (or expired) tokens will show the "invalidlink" message instead of triggering an error or other undefined behaviour.