### PR TITLE
HIDP-173 Catch integrity error and show form validation error

### DIFF
--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -942,7 +942,17 @@ class EmailChangeConfirmView(
         return self.email_change_request
 
     def form_valid(self, form):
-        form.save()
+        try:
+            form.save()
+        except IntegrityError:
+            form.add_error(
+                None,
+                _(
+                    "Sorry, changing your email address is not possible because an"
+                    " account with this email address already exists."
+                ),
+            )
+            return self.form_invalid(form)
         return HttpResponseRedirect(self.success_url)
 
 


### PR DESCRIPTION
Should only happen if an account was created with the proposed email address after the email change request was made. In this edge case we can assume that the authenticated user is the one who wants to change the email address of his/her account, because the confirm link has been clicked as well.
They might have accidentally created a new account with the proposed email address in the meantime.