### PR TITLE
HIDP-190 Exclude already confirmed requests in token validation

### DIFF
--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -428,17 +428,9 @@ msgid "Confirm email change"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
-msgid "Please go to your other inbox and look for the link there."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/management/email_change_confirm.html
 #: hidp/templates/hidp/accounts/verification/email_verification_required.html
 #: hidp/templates/hidp/accounts/verification/verify_email.html
 msgid "The link you followed is invalid. It may have expired or been used already."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/management/email_change_confirm.html
-msgid "You have already confirmed the change from this email address."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -429,18 +429,10 @@ msgid "Confirm email change"
 msgstr "Bevestig e-mailadres wijziging"
 
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
-msgid "Please go to your other inbox and look for the link there."
-msgstr "Ga naar je andere inbox en bevestig de wijziging:"
-
-#: hidp/templates/hidp/accounts/management/email_change_confirm.html
 #: hidp/templates/hidp/accounts/verification/email_verification_required.html
 #: hidp/templates/hidp/accounts/verification/verify_email.html
 msgid "The link you followed is invalid. It may have expired or been used already."
 msgstr "De link die je hebt gevolgd is ongeldig. Het kan zijn dat deze is verlopen of al is gebruikt."
-
-#: hidp/templates/hidp/accounts/management/email_change_confirm.html
-msgid "You have already confirmed the change from this email address."
-msgstr "Je hebt de wijziging al bevestigd vanaf dit e-mailadres."
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
 msgid "A password is required to confirm your identity."

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm.html
@@ -4,32 +4,26 @@
 {% block title %}{% translate 'Confirm email change' %}{% endblock %}
 
 {% block body %}
-  {% if already_confirmed_for_this_email %}
-  <p>{% translate 'You have already confirmed the change from this email address.'%}</p>
-  <p>{% translate 'Please go to your other inbox and look for the link there.'%}</p>
+  {% if validlink %}
+  <h1>{% translate 'Confirm email change' %}</h1>
+
+  <p>
+    {% blocktranslate trimmed %}
+    Are you sure you want to change your email address from {{ current_email }} to {{ proposed_email }}?
+    {% endblocktranslate %}
+  </p>
+  <p>{% translate "Please note that changing your email address will also change the username you use to login." %}</p>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">{% translate 'Confirm' %}</button>
+  </form>
+
   {% else %}
+  <p>
+    {% translate 'The link you followed is invalid. It may have expired or been used already.' %}
+  </p>
 
-    {% if validlink %}
-    <h1>{% translate 'Confirm email change' %}</h1>
-
-    <p>
-      {% blocktranslate trimmed %}
-      Are you sure you want to change your email address from {{ current_email }} to {{ proposed_email }}?
-      {% endblocktranslate %}
-    </p>
-    <p>{% translate "Please note that changing your email address will also change the username you use to login." %}</p>
-
-    <form method="post">
-      {% csrf_token %}
-      {{ form.as_p }}
-      <button type="submit">{% translate 'Confirm' %}</button>
-    </form>
-
-    {% else %}
-    <p>
-      {% translate 'The link you followed is invalid. It may have expired or been used already.' %}
-    </p>
-
-    {% endif %}
   {% endif %}
 {% endblock %}

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
@@ -380,11 +380,8 @@ class TestEmailChangeConfirm(TestCase):
             response, "hidp/accounts/management/email_change_confirm.html"
         )
         self.assertInHTML(
-            "You have already confirmed the change from this email address.",
-            response.content.decode(),
-        )
-        self.assertInHTML(
-            "Please go to your other inbox and look for the link there.",
+            "The link you followed is invalid."
+            " It may have expired or been used already.",
             response.content.decode(),
         )
 
@@ -498,6 +495,21 @@ class TestEmailChangeConfirm(TestCase):
             "Sorry, changing your email address is not possible because an"
             " account with this email address already exists.",
             response.context["form"].errors["__all__"],
+        )
+
+    def test_post_already_completed_request(self):
+        self.email_change_request.confirmed_by_current_email = True
+        self.email_change_request.confirmed_by_proposed_email = True
+        self.email_change_request.save()
+
+        response = self.client.post(
+            self.current_email_url, {"allow_change": "on"}, follow=True
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertInHTML(
+            "The link you followed is invalid."
+            " It may have expired or been used already.",
+            response.content.decode(),
         )
 
 


### PR DESCRIPTION
This makes the token invalid for already confirmed tokens, removing the need for the already_confirmed_by_this_email context