### PR TITLE
Split base templates for pre and post login pages

### DIFF
--- a/packages/hidp/docs/templates.md
+++ b/packages/hidp/docs/templates.md
@@ -18,11 +18,17 @@ The templates available are:
 
 ---
 
-## base.html
+## Base templates
 
-This is the base template that every template in HIdP extends. It includes the basic
-HTML boilerplate for each page. Override this template to load custom CSS, scripts,
-and set up a base layout.
+To facilitate the common use case of having a distinct layout for the pre-login and
+post-login pages, HIdP provides a base template hierarchy that you can extend to
+customize the layout of your application.
+
+### base.html
+
+This is the root base template that every template in HIdP extends. It includes the
+basic HTML boilerplate for each page. Override this template to load custom CSS,
+scripts, and set up a base layout.
 
 This template defines two blocks that all other templates depend on:
 
@@ -32,6 +38,9 @@ This template defines two blocks that all other templates depend on:
 `body`
 : inside the HTML `body` tag.
 
+`main`
+: inside the `body` block, where the main application content is rendered.
+
 This template also defines two blocks that you can extend to inject extra styles and/or
 scripts:
 
@@ -40,6 +49,16 @@ scripts:
 
 `extra_body`
 : inside the HTML body tag, below the `body` block.
+
+### base_pre_login.html
+
+This template extends `base.html` and is used for all pre-login pages. It does not
+add anything over the base template and is only provided as an extension point.
+
+### base_post_login.html
+
+This template extends `base.html` and is used for all post-login pages. It does not
+add anything over the base template and is only provided as an extension point.
 
 ---
 
@@ -51,6 +70,8 @@ can be found in this directory and subdirectories: `templates/hidp/accounts`.
 ### login.html
 
 Rendered by the `LoginView`.
+
+**Base template**: `base_pre_login.html`
 
 **Context variables**
 
@@ -88,7 +109,12 @@ Rendered by the `LoginView`.
 
 ### logout_confirm.html
 
-Rendered by the `RPInitiatedLogoutView`.
+Rendered by the `RPInitiatedLogoutView` and is used to confirm the logout.
+
+**Base template**: `base_pre_login.html`
+
+Using the pre-login base template might sound counterintuitive, but the logout
+confirmation page is shown regardless of the user's authentication status.
 
 **Context variables**
 
@@ -102,6 +128,8 @@ Rendered by the `RPInitiatedLogoutView`.
 ### register.html
 
 Rendered by the `RegistrationView`.
+
+**Base template**: `base_pre_login.html`
 
 **Context variables**
 
@@ -130,6 +158,8 @@ Rendered by the `RegistrationView`.
 
 Rendered by the `TermsOfServiceView`.
 
+**Base template**: `base_pre_login.html`
+
 :::{important}
 This template serves as an example and is not suited for use in production. Please
 override this template to provide your own Terms of Service or disable the
@@ -146,6 +176,8 @@ in `templates/hidp/accounts/management`.
 ### manage_account.html
 
 Rendered by the `ManageAccountView`.
+
+**Base template**: `base_post_login.html`
 
 **Context variables**
 
@@ -169,6 +201,8 @@ Rendered by the `ManageAccountView`.
 
 Rendered by the `EditAccountView`.
 
+**Base template**: `base_post_login.html`
+
 **Context variables**
 
 `form`
@@ -180,6 +214,8 @@ Rendered by the `EditAccountView`.
 ### oidc_linked_services.html
 
 Rendered by the `OIDCLinkedServicesView`.
+
+**Base template**: `base_post_login.html`
 
 **Context variables**
 
@@ -210,6 +246,8 @@ Rendered by the `PasswordChangeView`.
 
 Redirects to `PasswordChangeDoneView` after successfully changing the password.
 
+**Base template**: `base_post_login.html`
+
 **Context variables**
 
 `form`
@@ -222,6 +260,8 @@ Rendered by the `PasswordChangeDoneView`.
 
 Shows a message letting the user know that their password has been changed.
 
+**Base template**: `base_post_login.html`
+
 ### set_password.html
 
 Rendered by the `SetPasswordView`.
@@ -231,6 +271,8 @@ in order to set a password. If the user hasn't logged in recently they need to
 re-authenticate using one of the OIDC providers linked to their account.
 
 Redirects to `SetPasswordDoneView` after successfully setting the password.
+
+**Base template**: `base_post_login.html`
 
 **Context variables**
 
@@ -253,9 +295,13 @@ Rendered by the `SetPasswordDoneView`.
 
 Shows a message letting the user know that their password has been set.
 
+**Base template**: `base_post_login.html`
+
 ### email_change_request.html
 
 Rendered by the `EmailChangeRequestView`.
+
+**Base template**: `base_post_login.html`
 
 **Context variables**
 
@@ -267,9 +313,13 @@ Rendered by the `EmailChangeRequestView`.
 
 Rendered by the `EmailChangeRequestSentView`.
 
+**Base template**: `base_post_login.html`
+
 ### email_change_confirm.html
 
 Rendered by the `EmailChangeConfirmView`.
+
+**Base template**: `base_post_login.html`
 
 **Context variables**
 
@@ -299,6 +349,8 @@ If `validlink` is `True` the following context variables are also available:
 
 Rendered by the `EmailChangeCompleteView`.
 
+**Base template**: `base_post_login.html`
+
 **Context variables**
 
 `current_email_confirmation_required`
@@ -316,6 +368,8 @@ Rendered by the `EmailChangeCompleteView`.
 
 Rendered by the `EmailChangeCancelView`.
 
+**Base template**: `base_post_login.html`
+
 **Context variables**
 
 `validlink`
@@ -332,6 +386,8 @@ If `validlink` is `True` the following context variables are also available:
 ### email_change_cancel_done.html
 
 Rendered by the `EmailChangeCancelDoneView`.
+
+**Base template**: `base_post_login.html`
 
 ## accounts/management/email/
 
@@ -414,6 +470,8 @@ in `templates/hidp/accounts/recovery`.
 
 Rendered by the `PasswordResetRequestView`.
 
+**Base template**: `base_pre_login.html`
+
 **Context variables**
 
 `form`
@@ -423,9 +481,13 @@ Rendered by the `PasswordResetRequestView`.
 
 Rendered by the `PasswordResetEmailSentView`.
 
+**Base template**: `base_pre_login.html`
+
 ### password_reset.html
 
 Rendered by the `PasswordResetView`, which is a subclass of Django's `PasswordResetConfirmView`.
+
+**Base template**: `base_pre_login.html`
 
 **Context variables**
 
@@ -438,6 +500,8 @@ Rendered by the `PasswordResetView`, which is a subclass of Django's `PasswordRe
 ### password_reset_complete.html
 
 Rendered by the `PasswordResetCompleteView`.
+
+**Base template**: `base_pre_login.html`
 
 **Context variables**
 
@@ -489,6 +553,8 @@ in `templates/hidp/accounts/verification`.
 
 Rendered by the `EmailVerificationRequiredView`.
 
+**Base template**: `base_pre_login.html`
+
 **Context variables**
 
 `validlink`
@@ -497,6 +563,8 @@ Rendered by the `EmailVerificationRequiredView`.
 ### verify_email.html
 
 Rendered by the `EmailVerificationView`.
+
+**Base template**: `base_pre_login.html`
 
 **Context variables**
 
@@ -509,6 +577,8 @@ Rendered by the `EmailVerificationView`.
 ### email_verification_complete.html
 
 Rendered by the `EmailVerificationCompleteView`.
+
+**Base template**: `base_pre_login.html`
 
 **Context variables**
 
@@ -560,6 +630,8 @@ Rendered by the `OIDCAccountLinkView`.
 Redirects to `OIDCLinkedServicesView` after successfully linking the account to the
 OIDC provider.
 
+**Base template**: `base_post_login.html`
+
 **Context variables**
 
 `form`
@@ -581,6 +653,8 @@ Rendered by the `OIDCAccountUnlinkView`.
 Redirects to `OIDCLinkedServicesView` after successfully unlinking the account from the
 OIDC provider.
 
+**Base template**: `base_post_login.html`
+
 **Context variables**
 
 `form`
@@ -592,6 +666,8 @@ OIDC provider.
 ### registration.html
 
 Rendered by the `OIDCRegistrationView`.
+
+**Base template**: `base_pre_login.html`
 
 **Context variables**
 

--- a/packages/hidp/hidp/templates/hidp/accounts/login.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/login.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Log in' %}{% endblock %}
 
-{% block body %}
+{% block main %}
 {% if oidc_error_message %}
 <ul>
   <li>

--- a/packages/hidp/hidp/templates/hidp/accounts/logout_confirm.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/logout_confirm.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Logout' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   {% if not error %}
 
   {% if application %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/edit_account.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/edit_account.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Edit account' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Edit your account information' %}</h1>
 
   {% if show_success_message %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Cancel email change' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Cancel email change' %}</h1>
 
   {% if not validlink %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel_done.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel_done.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Cancel email change' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Cancel email change' %}</h1>
   <p>{% translate 'Successfully cancelled the email address change.' %}</p>
 

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_complete.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_complete.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Change email address' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Change email address' %}</h1>
 
   {% if current_email_confirmation_required %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Confirm email change' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   {% if validlink %}
   <h1>{% translate 'Confirm email change' %}</h1>
 

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Change email address' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Change email address' %}</h1>
 
   {% if not can_change_email %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request_sent.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request_sent.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Change email address' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <p>{% translate "We've emailed you on your current and new email address to confirm the change. You should receive both emails shortly." %}</p>
   <p>{% translate "If you don't receive an email, please make sure you've entered the correct new address, and check your spam folder." %}</p>
   <p>{% translate "Only after you confirmed through both email addresses, your email address will be changed." %}</p>

--- a/packages/hidp/hidp/templates/hidp/accounts/management/manage_account.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/manage_account.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Manage account' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Manage your account information' %}</h1>
 
   <form action="{{ logout_url }}" method="post">

--- a/packages/hidp/hidp/templates/hidp/accounts/management/oidc_linked_services.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/oidc_linked_services.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Manage linked trusted services' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Manage your linked trusted services' %}</h1>
 
   {% if oidc_error_message %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/password_change.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/password_change.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Change password' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Change password' %}</h1>
 
   <form action="{% url 'hidp_accounts:change_password' %}" method="post">

--- a/packages/hidp/hidp/templates/hidp/accounts/management/password_change_done.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/password_change_done.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Change password' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Change password' %}</h1>
 
   <p>{% translate 'Your password has been changed.' %}</p>

--- a/packages/hidp/hidp/templates/hidp/accounts/management/set_password.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/set_password.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Set password' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Set password' %}</h1>
 
   {% if must_reauthenticate %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/set_password_done.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/set_password_done.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Set password' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Set password' %}</h1>
 
   <p>{% translate 'Your password has been set.' %}</p>

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Reset password' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   {% if validlink %}
   <p>{% translate "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
 

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_complete.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_complete.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Reset password' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <p>{% translate "Your password has been set. You may go ahead and log in now." %}</p>
 
   <p><a href="{{ login_url }}">{% translate 'Log in' %}</a></p>

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Reset password' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <p>
     {% blocktranslate trimmed %}
     We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly.

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_request.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_request.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Reset password' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <p>
     {% blocktranslate trimmed %}
     Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one.

--- a/packages/hidp/hidp/templates/hidp/accounts/register.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/register.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Sign up' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Create a new account' %}</h1>
 
   {% if oidc_error_message %}

--- a/packages/hidp/hidp/templates/hidp/accounts/tos.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/tos.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate "Terms of Service" %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate "Terms of Service" %}</h1>
 
   {% comment %}

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_complete.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_complete.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Verification completed' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Verification completed' %}</h1>
 
   <p>

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_required.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_required.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Verification required' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   {% if validlink %}
   <h1>{% translate 'Verification required' %}</h1>
 

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/verify_email.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/verify_email.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Verify email' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   {% if validlink %}
   <h1>{% translate 'Verify email' %}</h1>
 

--- a/packages/hidp/hidp/templates/hidp/base.html
+++ b/packages/hidp/hidp/templates/hidp/base.html
@@ -8,6 +8,7 @@
 </head>
 <body>
 {% block body %}
+  {% block main %}{# Main application content #}{% endblock %}
 {% endblock %}
 {% block extra_body %}
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/base_post_login.html
+++ b/packages/hidp/hidp/templates/hidp/base_post_login.html
@@ -1,0 +1,13 @@
+{% extends 'hidp/base.html' %}
+{% comment %}
+This template serves as the base template for all pages that are displayed after a user is logged-in.
+
+This includes the following pages (non-exhaustive list):
+
+- Profile management
+- Password change flow
+- OIDC account (un)linking flow
+- Email change flow
+
+It extends the base.html template and is an entrypoint for customizing the layout of the post-login pages.
+{% endcomment %}

--- a/packages/hidp/hidp/templates/hidp/base_pre_login.html
+++ b/packages/hidp/hidp/templates/hidp/base_pre_login.html
@@ -1,0 +1,15 @@
+{% extends 'hidp/base.html' %}
+{% comment %}
+This template serves as the base template for all pages that are displayed before a user is logged-in.
+
+This includes the following pages (non-exhaustive list):
+
+- Registration flow
+- Email verification flow
+- Login flow
+- Password reset flow
+- Terms of service
+- Logout confirmation
+
+It extends the base.html template and is an entrypoint for customizing the layout of the pre-login pages.
+{% endcomment %}

--- a/packages/hidp/hidp/templates/hidp/federated/account_link.html
+++ b/packages/hidp/hidp/templates/hidp/federated/account_link.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Link account' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Link account' %}</h1>
 
   <p>

--- a/packages/hidp/hidp/templates/hidp/federated/account_unlink.html
+++ b/packages/hidp/hidp/templates/hidp/federated/account_unlink.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_post_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Unlink account' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Unlink account' %}</h1>
 
   <p>
@@ -27,7 +27,7 @@
       {% endfor %}
     </ul>
   {% endif %}
-  
+
   <form method="post">
     {% csrf_token %}
     <button type="submit" name="allow_unlink" value="true">

--- a/packages/hidp/hidp/templates/hidp/federated/registration.html
+++ b/packages/hidp/hidp/templates/hidp/federated/registration.html
@@ -1,9 +1,9 @@
-{% extends "hidp/base.html" %}
+{% extends "hidp/base_pre_login.html" %}
 {% load i18n %}
 
 {% block title %}{% translate 'Sign up' %}{% endblock %}
 
-{% block body %}
+{% block main %}
   <h1>{% translate 'Create a new account' %}</h1>
 
   <form method="post">


### PR DESCRIPTION
Allows to have a custom look and feel for the pre- and post-login pages without any overrides in the implementing project.

Adding the `main` block inside the `body` block makes it more easy to wrap the application content.