### PR TITLE
HIDP-188 Add email changed mailer and send when email change request completes

### DIFF
--- a/packages/hidp/docs/templates.md
+++ b/packages/hidp/docs/templates.md
@@ -439,6 +439,23 @@ requests to change their email address.
 
 The subject of the email is set with this template: `email_change_subject.txt`.
 
+### email_changed_body.txt
+
+Sent by the `EmailChangeConfirmView` to both old and new email address when a user
+changed their email address.
+
+**Context variables**
+
+`current_email`
+: The current email address.
+
+`proposed_email`
+: The proposed new email address.
+
+### email_changed_subject.txt
+
+The subject of the email is set with this template: `email_changed_subject.txt`.
+
 ### proposed_email_exists_body.txt
 
 Sent by the `EmailChangeRequestView` to the new email address when a user

--- a/packages/hidp/hidp/accounts/mailers.py
+++ b/packages/hidp/hidp/accounts/mailers.py
@@ -302,3 +302,28 @@ class ProposedEmailExistsMailer(EmailChangeRequestMailer):
             "proposed_email": self.email_change_request.proposed_email,
             "cancel_url": self.get_cancel_url(),
         }
+
+
+class EmailChangedMailer(BaseMailer):
+    subject_template_name = "hidp/accounts/management/email/email_changed_subject.txt"
+    email_template_name = "hidp/accounts/management/email/email_changed_body.txt"
+
+    def __init__(self, user, *, email_change_request, base_url):
+        super().__init__(base_url=base_url)
+        self.user = user
+        self.email_change_request = email_change_request
+
+    def get_context(self, extra_context=None):
+        return super().get_context(
+            {
+                "current_email": self.email_change_request.current_email,
+                "proposed_email": self.email_change_request.proposed_email,
+            }
+            | (extra_context or {})
+        )
+
+    def get_recipients(self):
+        return [
+            self.email_change_request.current_email,
+            self.email_change_request.proposed_email,
+        ]

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -334,6 +334,20 @@ msgstr ""
 msgid "Confirm your email change request"
 msgstr ""
 
+#: hidp/templates/hidp/accounts/management/email/email_changed_body.txt
+#, python-format
+msgid "Please note that this means you'll need to use %(proposed_email)s to log in from now on."
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email/email_changed_body.txt
+#, python-format
+msgid "You're receiving this email because the email address of your account has been changed from %(current_email)s to %(proposed_email)s."
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email/email_changed_subject.txt
+msgid "Email address changed"
+msgstr ""
+
 #: hidp/templates/hidp/accounts/management/email/password_changed_body.txt
 msgid "If you did not change your password, please reset your password immediately using this link:"
 msgstr ""

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -335,6 +335,20 @@ msgstr "Je ontvangt deze e-mail omdat je je e-mailadres wilt wijzigen van %(curr
 msgid "Confirm your email change request"
 msgstr "Bevestig je verzoek om je e-mailadres te wijzigen"
 
+#: hidp/templates/hidp/accounts/management/email/email_changed_body.txt
+#, python-format
+msgid "Please note that this means you'll need to use %(proposed_email)s to log in from now on."
+msgstr "Houd er rekening mee dat je vanaf nu met %(proposed_email)s moet inloggen."
+
+#: hidp/templates/hidp/accounts/management/email/email_changed_body.txt
+#, python-format
+msgid "You're receiving this email because the email address of your account has been changed from %(current_email)s to %(proposed_email)s."
+msgstr "Je ontvangt deze e-mail omdat het e-mailadres van je account is gewijzigd van %(current_email)s naar %(proposed_email)s."
+
+#: hidp/templates/hidp/accounts/management/email/email_changed_subject.txt
+msgid "Email address changed"
+msgstr "E-mailadres is gewijzigd"
+
 #: hidp/templates/hidp/accounts/management/email/password_changed_body.txt
 msgid "If you did not change your password, please reset your password immediately using this link:"
 msgstr "Als je dit niet zelf hebt gedaan, wijzig dan meteen je wachtwoord met de volgende link:"

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email/email_changed_body.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email/email_changed_body.txt
@@ -1,0 +1,10 @@
+{% load i18n %}{% autoescape off %}
+{% blocktranslate trimmed %}
+You're receiving this email because the email address of your account has been changed from {{ current_email }} to {{ proposed_email }}.
+{% endblocktranslate %}
+
+{% blocktranslate trimmed %}
+Please note that this means you'll need to use {{ proposed_email }} to log in from now on.
+{% endblocktranslate %}
+
+{% endautoescape %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email/email_changed_subject.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email/email_changed_subject.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% autoescape off %}
+{% translate "Email address changed" %}
+{% endautoescape %}


### PR DESCRIPTION
This adds a confirmation mail to users that just changed their email address with a reminder that they need to login with their new email address

- [x] add documentation