### PR TITLE
Fix messags of SymbolValidator

### DIFF
--- a/packages/hidp/hidp/accounts/password_validation.py
+++ b/packages/hidp/hidp/accounts/password_validation.py
@@ -2,6 +2,7 @@ import re
 import string
 
 from django.core.exceptions import ValidationError
+from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 
 
@@ -42,12 +43,12 @@ class LowercaseValidator(RegexValidator):
 
 class SymbolValidator(RegexValidator):
     regex = "|".join(re.escape(c) for c in string.punctuation)
-    message = _(
-        _("This password does not contain any special characters (%s).")
-        % string.punctuation
+    message = format_lazy(
+        _("This password does not contain any special characters ({})."),
+        string.punctuation,
     )
     code = "password_no_symbol"
-    help_text = _(
-        _("Your password must contain at least one special character (%s).")
-        % string.punctuation
+    help_text = format_lazy(
+        _("Your password must contain at least one special character ({})."),
+        string.punctuation,
     )

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -115,6 +115,10 @@ msgid "This password does not contain any special characters (%s)."
 msgstr ""
 
 #: hidp/accounts/password_validation.py
+msgid "This password does not contain any special characters ({})."
+msgstr ""
+
+#: hidp/accounts/password_validation.py
 msgid "This password does not contain any uppercase characters (A-Z)."
 msgstr ""
 
@@ -129,6 +133,10 @@ msgstr ""
 #: hidp/accounts/password_validation.py
 #, python-format
 msgid "Your password must contain at least one special character (%s)."
+msgstr ""
+
+#: hidp/accounts/password_validation.py
+msgid "Your password must contain at least one special character ({})."
 msgstr ""
 
 #: hidp/accounts/password_validation.py

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -116,6 +116,10 @@ msgid "This password does not contain any special characters (%s)."
 msgstr "Dit wachtwoord bevat geen speciale tekens (%s)."
 
 #: hidp/accounts/password_validation.py
+msgid "This password does not contain any special characters ({})."
+msgstr "Dit wachtwoord bevat geen speciale tekens ({})."
+
+#: hidp/accounts/password_validation.py
 msgid "This password does not contain any uppercase characters (A-Z)."
 msgstr "Dit wachtwoord bevat geen hoofdletters (A-Z)."
 
@@ -131,6 +135,10 @@ msgstr "Uw wachtwoord moet minstens één kleine letter bevatten (a-z)."
 #, python-format
 msgid "Your password must contain at least one special character (%s)."
 msgstr "Uw wachtwoord moet minstens één speciaal teken bevatten (%s)."
+
+#: hidp/accounts/password_validation.py
+msgid "Your password must contain at least one special character ({})."
+msgstr "Uw wachtwoord moet minstens één speciaal teken bevatten ({})."
 
 #: hidp/accounts/password_validation.py
 msgid "Your password must contain at least one uppercase character (A-Z)."


### PR DESCRIPTION
The formatting was executed eagerly, therefore the translation was never picked up (it was always English). Formatting these strings lazily fixes this.