### PR TITLE
Move some template content to form help text

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -312,11 +312,16 @@ class EmailChangeRequestForm(forms.ModelForm):
         label=_("New email"),
         max_length=254,
         widget=forms.EmailInput(),
+        help_text=_(
+            "Please note that changing your email address will also"
+            " change the username you use to login."
+        ),
     )
     password = forms.CharField(
         label=_("Password"),
         strip=False,
-        widget=forms.PasswordInput(attrs={"autocomplete": "password"}),
+        widget=forms.PasswordInput(attrs={"autocomplete": "current-password"}),
+        help_text=_("Your password is required to verify your identity."),
     )
 
     class Meta:

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -32,6 +32,14 @@ msgid "Please confirm that you are not a robot."
 msgstr ""
 
 #: hidp/accounts/forms.py
+#: hidp/templates/hidp/accounts/management/email/email_change_body.txt
+#: hidp/templates/hidp/accounts/management/email_change_confirm.html
+#: hidp/templates/hidp/accounts/management/email_change_request.html
+#: hidp/templates/hidp/accounts/management/email_change_request_sent.html
+msgid "Please note that changing your email address will also change the username you use to login."
+msgstr ""
+
+#: hidp/accounts/forms.py
 msgid "The new email address is the same as the current email address."
 msgstr ""
 
@@ -47,6 +55,11 @@ msgstr ""
 #: hidp/accounts/forms.py
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 msgid "Yes, I want to change my email address"
+msgstr ""
+
+#: hidp/accounts/forms.py
+#: hidp/templates/hidp/accounts/management/email_change_request.html
+msgid "Your password is required to verify your identity."
 msgstr ""
 
 #: hidp/accounts/models.py
@@ -323,13 +336,6 @@ msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
 msgid "Please go to the following page and confirm the change:"
-msgstr ""
-
-#: hidp/templates/hidp/accounts/management/email/email_change_body.txt
-#: hidp/templates/hidp/accounts/management/email_change_confirm.html
-#: hidp/templates/hidp/accounts/management/email_change_request.html
-#: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "Please note that changing your email address will also change the username you use to login."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -33,6 +33,14 @@ msgid "Please confirm that you are not a robot."
 msgstr "Bevestig dat je geen robot bent."
 
 #: hidp/accounts/forms.py
+#: hidp/templates/hidp/accounts/management/email/email_change_body.txt
+#: hidp/templates/hidp/accounts/management/email_change_confirm.html
+#: hidp/templates/hidp/accounts/management/email_change_request.html
+#: hidp/templates/hidp/accounts/management/email_change_request_sent.html
+msgid "Please note that changing your email address will also change the username you use to login."
+msgstr "Houd er rekening mee dat het wijzigen van je e-mailadres ook je inlognaam verandert."
+
+#: hidp/accounts/forms.py
 msgid "The new email address is the same as the current email address."
 msgstr "Het nieuwe e-mailadres is hetzelfde als het huidige e-mailadres."
 
@@ -49,6 +57,11 @@ msgstr "Ja, ik wil het wijzigen van mijn e-mailadres annuleren"
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 msgid "Yes, I want to change my email address"
 msgstr "Ja, ik wil mijn e-mailadres wijzigen"
+
+#: hidp/accounts/forms.py
+#: hidp/templates/hidp/accounts/management/email_change_request.html
+msgid "Your password is required to verify your identity."
+msgstr "Je wachtwoord is nodig om je identiteit te verfifiëren."
 
 #: hidp/accounts/models.py
 msgid "agreed to terms of service"
@@ -325,13 +338,6 @@ msgstr "Als je deze wijziging niet hebt aangevraagd, kun je het verzoek annulere
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
 msgid "Please go to the following page and confirm the change:"
 msgstr "Ga naar de volgende pagina en bevestig de wijziging:"
-
-#: hidp/templates/hidp/accounts/management/email/email_change_body.txt
-#: hidp/templates/hidp/accounts/management/email_change_confirm.html
-#: hidp/templates/hidp/accounts/management/email_change_request.html
-#: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "Please note that changing your email address will also change the username you use to login."
-msgstr "Houd er rekening mee dat het wijzigen van je e-mailadres ook je inlognaam verandert."
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
 #: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request.html
@@ -8,15 +8,12 @@
 
   {% if not can_change_email %}
     <p>{% translate 'You cannot change your email address because you do not have a password set.' %}</p>
-    <p>{% translate 'A password is required to confirm your identity.' %}</p>
-    <p>{% translate 'Please set a password first.' %}</p>
+    <p>{% translate 'Your password is required to verify your identity.' %}</p>
     <a href="{% url 'hidp_accounts:set_password' %}">{% translate 'Set password' %}</a>
 
   {% else %}
     <p>{% translate 'Enter your new email address.' %}</p>
-    <p>{% translate 'Your password is required to confirm your identity.' %}
     <p>{% translate 'You will receive an email on your current and new email address with a link to confirm the change.' %}</p>
-    <p>{% translate 'Please note that changing your email address will also change the username you use to login.' %}</p>
 
     <form action="{% url 'hidp_accounts:email_change_request' %}" method="post">
       {% csrf_token %}

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
@@ -52,10 +52,6 @@ class TestEmailChangeRequest(TestCase):
             response.content.decode(),
         )
         self.assertInHTML(
-            "Please set a password first.",
-            response.content.decode(),
-        )
-        self.assertInHTML(
             '<a href="/manage/set-password/">Set password</a>',
             response.content.decode(),
         )


### PR DESCRIPTION
Mostly so I can make it look nicer and align it with the password change form in the AT implementation:

<img width="920" alt="Screenshot 2024-10-28 at 10 32 42" src="https://github.com/user-attachments/assets/1f7d5ae0-de7a-4ff9-962e-8570cf11f94f">

Password change uses a similar message for the "confirm password" field:

<img width="902" alt="Screenshot 2024-10-28 at 10 32 58" src="https://github.com/user-attachments/assets/8a9608da-390c-43af-a54d-c19acab91332">