### PR TITLE
Remove trailing dot from ToS label

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -19,7 +19,7 @@ class TermsOfServiceMixin:
     def create_agreed_to_tos_field():
         label = mark_safe(  # noqa: S308 (safe string, no user input)
             format_lazy(
-                _('I have read and accept the <a href="{url}">Terms of Service</a>.'),
+                _('I have read and accept the <a href="{url}">Terms of Service</a>'),
                 url=reverse_lazy("hidp_accounts:tos"),
             )
         )

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -16,7 +16,7 @@ msgstr ""
 
 #: hidp/accounts/forms.py
 #, python-brace-format
-msgid "I have read and accept the <a href=\"{url}\">Terms of Service</a>."
+msgid "I have read and accept the <a href=\"{url}\">Terms of Service</a>"
 msgstr ""
 
 #: hidp/accounts/forms.py

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -17,8 +17,8 @@ msgstr "Ik ben geen robot"
 
 #: hidp/accounts/forms.py
 #, python-brace-format
-msgid "I have read and accept the <a href=\"{url}\">Terms of Service</a>."
-msgstr "Ik heb de <a href=\"{url}\">Servicevoorwaarden</a> gelezen en accepteer ze."
+msgid "I have read and accept the <a href=\"{url}\">Terms of Service</a>"
+msgstr "Ik heb de <a href=\"{url}\">Servicevoorwaarden</a> gelezen en accepteer ze"
 
 #: hidp/accounts/forms.py
 msgid "New email"


### PR DESCRIPTION
This makes Django render it as a "normal" label (with a `:` at the end).