### PR TITLE
Remove error header from logout_confirm template

### DIFF
--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -265,10 +265,6 @@ msgid "Cancel"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/logout_confirm.html
-msgid "Error"
-msgstr ""
-
-#: hidp/templates/hidp/accounts/logout_confirm.html
 #: hidp/templates/hidp/accounts/management/manage_account.html
 #: hidp/templates/hidp/accounts/register.html
 msgid "Log out"

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -266,10 +266,6 @@ msgid "Cancel"
 msgstr "Annuleren"
 
 #: hidp/templates/hidp/accounts/logout_confirm.html
-msgid "Error"
-msgstr "Error"
-
-#: hidp/templates/hidp/accounts/logout_confirm.html
 #: hidp/templates/hidp/accounts/management/manage_account.html
 #: hidp/templates/hidp/accounts/register.html
 msgid "Log out"

--- a/packages/hidp/hidp/templates/hidp/accounts/logout_confirm.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/logout_confirm.html
@@ -30,7 +30,6 @@
   </form>
 
   {% else %}
-  <h1>{% translate 'Error' %}: {{ error.error }}</h1>
   <p>{{ error.description }}</p>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
The would just show

> Error: logout_cancelled

or something like that, not very useful