### PR TITLE
Move account management into it's own namespace

### DIFF
--- a/packages/hidp/hidp/accounts/account_management_urls.py
+++ b/packages/hidp/hidp/accounts/account_management_urls.py
@@ -1,0 +1,98 @@
+"""
+Account management URLs.
+
+Provides the URL patterns for the account management features.
+
+Include this module in the root URL configuration:
+
+    from hidp.accounts import account_management_urls
+
+    urlpatterns = [
+        path("manage/", include(account_management_urls)),
+    ]
+
+This module also defines the namespace `hidp_account_management` for these URLs.
+
+Include this namespace when reversing URLs, for example:
+
+    reverse("hidp_account_management:manage_account")
+"""
+
+from django.urls import path
+
+from . import views
+
+app_name = "hidp_account_management"
+
+account_urls = [
+    path("", views.ManageAccountView.as_view(), name="manage_account"),
+    path("edit-account/", views.EditAccountView.as_view(), name="edit_account"),
+    path(
+        "edit-account/done/",
+        views.EditAccountDoneView.as_view(),
+        name="edit_account_done",
+    ),
+]
+
+change_password_urls = [
+    path(
+        "change-password/",
+        views.PasswordChangeView.as_view(),
+        name="change_password",
+    ),
+    path(
+        "change-password/done/",
+        views.PasswordChangeDoneView.as_view(),
+        name="change_password_done",
+    ),
+]
+
+set_password_urls = [
+    path(
+        "set-password/",
+        views.SetPasswordView.as_view(),
+        name="set_password",
+    ),
+    path(
+        "set-password/done/",
+        views.SetPasswordDoneView.as_view(),
+        name="set_password_done",
+    ),
+]
+
+change_email_urls = [
+    path(
+        "change-email/",
+        views.EmailChangeRequestView.as_view(),
+        name="email_change_request",
+    ),
+    path(
+        "change-email/sent/",
+        views.EmailChangeRequestSentView.as_view(),
+        name="email_change_request_sent",
+    ),
+    path(
+        "change-email-confirm/<token>/",
+        views.EmailChangeConfirmView.as_view(),
+        name="email_change_confirm",
+    ),
+    path(
+        "change-email-complete/",
+        views.EmailChangeCompleteView.as_view(),
+        name="email_change_complete",
+    ),
+    path(
+        "change-email-cancel/",
+        views.EmailChangeCancelView.as_view(),
+        name="email_change_cancel",
+    ),
+    path(
+        "change-email-cancel-done/",
+        views.EmailChangeCancelDoneView.as_view(),
+        name="email_change_cancel_done",
+    ),
+]
+
+urlpatterns = (
+    account_urls + change_password_urls + set_password_urls + change_email_urls
+)

--- a/packages/hidp/hidp/accounts/account_urls.py
+++ b/packages/hidp/hidp/accounts/account_urls.py
@@ -1,7 +1,7 @@
 """
 Authentication URLs.
 
-Provides the URL patterns for the accounts views (register, login, logout).
+Provides the URL patterns for the base accounts features.
 
 Include this module in the root URL configuration:
 
@@ -82,84 +82,4 @@ recover_urls = [
     )
 ]
 
-account_urls = [
-    path("", views.ManageAccountView.as_view(), name="manage_account"),
-    path("edit-account/", views.EditAccountView.as_view(), name="edit_account"),
-    path(
-        "edit-account/done/",
-        views.EditAccountDoneView.as_view(),
-        name="edit_account_done",
-    ),
-]
-
-change_password_urls = [
-    path(
-        "change-password/",
-        views.PasswordChangeView.as_view(),
-        name="change_password",
-    ),
-    path(
-        "change-password/done/",
-        views.PasswordChangeDoneView.as_view(),
-        name="change_password_done",
-    ),
-]
-
-set_password_urls = [
-    path(
-        "set-password/",
-        views.SetPasswordView.as_view(),
-        name="set_password",
-    ),
-    path(
-        "set-password/done/",
-        views.SetPasswordDoneView.as_view(),
-        name="set_password_done",
-    ),
-]
-
-change_email_urls = [
-    path(
-        "change-email/",
-        views.EmailChangeRequestView.as_view(),
-        name="email_change_request",
-    ),
-    path(
-        "change-email/sent/",
-        views.EmailChangeRequestSentView.as_view(),
-        name="email_change_request_sent",
-    ),
-    path(
-        "change-email-confirm/<token>/",
-        views.EmailChangeConfirmView.as_view(),
-        name="email_change_confirm",
-    ),
-    path(
-        "change-email-complete/",
-        views.EmailChangeCompleteView.as_view(),
-        name="email_change_complete",
-    ),
-    path(
-        "change-email-cancel/",
-        views.EmailChangeCancelView.as_view(),
-        name="email_change_cancel",
-    ),
-    path(
-        "change-email-cancel-done/",
-        views.EmailChangeCancelDoneView.as_view(),
-        name="email_change_cancel_done",
-    ),
-]
-
-management_urls = [
-    path(
-        "manage/",
-        include(
-            account_urls + change_password_urls + set_password_urls + change_email_urls
-        ),
-    ),
-]
-
-urlpatterns = (
-    register_urls + verifications_urls + auth_urls + recover_urls + management_urls
-)
+urlpatterns = register_urls + verifications_urls + auth_urls + recover_urls

--- a/packages/hidp/hidp/accounts/mailers.py
+++ b/packages/hidp/hidp/accounts/mailers.py
@@ -193,7 +193,7 @@ class SetPasswordMailer(BaseMailer):
         self.user = user
 
     def get_set_password_url(self):
-        return urljoin(self.base_url, reverse("hidp_accounts:set_password"))
+        return urljoin(self.base_url, reverse("hidp_account_management:set_password"))
 
     def get_context(self, extra_context=None):
         return super().get_context(
@@ -248,7 +248,7 @@ class EmailChangeRequestMailer(BaseMailer):
         return urljoin(
             self.base_url,
             reverse(
-                "hidp_accounts:email_change_confirm",
+                "hidp_account_management:email_change_confirm",
                 kwargs={
                     "token": (
                         tokens.email_change_token_generator.make_token(
@@ -262,7 +262,7 @@ class EmailChangeRequestMailer(BaseMailer):
     def get_cancel_url(self):
         return urljoin(
             self.base_url,
-            reverse("hidp_accounts:email_change_cancel"),
+            reverse("hidp_account_management:email_change_cancel"),
         )
 
     def get_context(self, extra_context=None):

--- a/packages/hidp/hidp/config/urls.py
+++ b/packages/hidp/hidp/config/urls.py
@@ -1,12 +1,13 @@
 from django.conf import settings
 from django.urls import include, path
 
-from ..accounts import account_urls
+from ..accounts import account_management_urls, account_urls
 from ..federated import oidc_client_urls, oidc_management_urls
 
 urlpatterns = [
     path("", include(account_urls)),
     path("login/oidc/", include(oidc_client_urls)),
+    path("manage/", include(account_management_urls)),
     path("manage/oidc/", include(oidc_management_urls)),
 ]
 

--- a/packages/hidp/hidp/federated/views.py
+++ b/packages/hidp/hidp/federated/views.py
@@ -507,7 +507,7 @@ class OIDCLinkedServicesView(
                 label=_("Link with {provider}"),
             ),
             "can_unlink": can_unlink,
-            "set_password_url": reverse("hidp_accounts:set_password"),
-            "back_url": reverse("hidp_accounts:manage_account"),
+            "set_password_url": reverse("hidp_account_management:set_password"),
+            "back_url": reverse("hidp_account_management:manage_account"),
         }
         return super().get_context_data() | context | kwargs

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
@@ -20,7 +20,7 @@ class TestEmailChangeRequest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = user_factories.UserFactory()
-        cls.url = reverse("hidp_accounts:email_change_request")
+        cls.url = reverse("hidp_account_management:email_change_request")
 
     def setUp(self):
         self.client.force_login(self.user)
@@ -82,7 +82,7 @@ class TestEmailChangeRequest(TestCase):
             )
 
         self.assertRedirects(
-            response, reverse("hidp_accounts:email_change_request_sent")
+            response, reverse("hidp_account_management:email_change_request_sent")
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_request_sent.html"
@@ -159,7 +159,7 @@ class TestEmailChangeRequest(TestCase):
             )
 
         self.assertRedirects(
-            response, reverse("hidp_accounts:email_change_request_sent")
+            response, reverse("hidp_account_management:email_change_request_sent")
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_request_sent.html"
@@ -227,7 +227,7 @@ class TestEmailChangeRequest(TestCase):
         )
 
         self.assertRedirects(
-            response, reverse("hidp_accounts:email_change_request_sent")
+            response, reverse("hidp_account_management:email_change_request_sent")
         )
 
         # Email should be sent to current email, but not to proposed email (inactive)
@@ -309,7 +309,7 @@ class TestEmailChangeConfirm(TestCase):
             user=cls.user, proposed_email="newemail@example.com"
         )
         cls.current_email_url = reverse(
-            "hidp_accounts:email_change_confirm",
+            "hidp_account_management:email_change_confirm",
             kwargs={
                 "token": tokens.email_change_token_generator.make_token(
                     str(cls.email_change_request.pk), "current_email"
@@ -317,7 +317,7 @@ class TestEmailChangeConfirm(TestCase):
             },
         )
         cls.proposed_email_url = reverse(
-            "hidp_accounts:email_change_confirm",
+            "hidp_account_management:email_change_confirm",
             kwargs={
                 "token": tokens.email_change_token_generator.make_token(
                     str(cls.email_change_request.pk), "proposed_email"
@@ -337,7 +337,7 @@ class TestEmailChangeConfirm(TestCase):
     def test_get_invalid_token(self):
         response = self.client.get(
             reverse(
-                "hidp_accounts:email_change_confirm",
+                "hidp_account_management:email_change_confirm",
                 kwargs={"token": "invalid"},
             ),
             follow=True,
@@ -355,7 +355,7 @@ class TestEmailChangeConfirm(TestCase):
         """Placeholder token, no token in session."""
         response = self.client.get(
             reverse(
-                "hidp_accounts:email_change_confirm",
+                "hidp_account_management:email_change_confirm",
                 kwargs={"token": "email-change"},
             ),
             follow=True,
@@ -408,7 +408,9 @@ class TestEmailChangeConfirm(TestCase):
             self.current_email_url, {"allow_change": "on"}, follow=True
         )
         self.assertRedirects(
-            response, reverse("hidp_accounts:email_change_complete"), status_code=308
+            response,
+            reverse("hidp_account_management:email_change_complete"),
+            status_code=308,
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_complete.html"
@@ -436,7 +438,9 @@ class TestEmailChangeConfirm(TestCase):
             self.proposed_email_url, {"allow_change": "on"}, follow=True
         )
         self.assertRedirects(
-            response, reverse("hidp_accounts:email_change_complete"), status_code=308
+            response,
+            reverse("hidp_account_management:email_change_complete"),
+            status_code=308,
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_complete.html"
@@ -467,7 +471,9 @@ class TestEmailChangeConfirm(TestCase):
             self.proposed_email_url, {"allow_change": "on"}, follow=True
         )
         self.assertRedirects(
-            response, reverse("hidp_accounts:email_change_complete"), status_code=308
+            response,
+            reverse("hidp_account_management:email_change_complete"),
+            status_code=308,
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_complete.html"
@@ -515,7 +521,7 @@ class TestEmailChangeConfirm(TestCase):
     def test_post_invalid_token(self):
         response = self.client.post(
             reverse(
-                "hidp_accounts:email_change_confirm",
+                "hidp_account_management:email_change_confirm",
                 kwargs={"token": "invalid"},
             ),
             {"allow_change": "on"},
@@ -573,7 +579,7 @@ class TestEmailChangeCancel(TestCase):
         cls.email_change_request = user_factories.EmailChangeRequestFactory(
             user=cls.user
         )
-        cls.url = reverse("hidp_accounts:email_change_cancel")
+        cls.url = reverse("hidp_account_management:email_change_cancel")
 
     def setUp(self):
         self.client.force_login(self.user)
@@ -658,7 +664,7 @@ class TestEmailChangeCancel(TestCase):
         response = self.client.post(self.url, {"allow_cancel": "on"}, follow=True)
         self.assertRedirects(
             response,
-            reverse("hidp_accounts:email_change_cancel_done"),
+            reverse("hidp_account_management:email_change_cancel_done"),
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_cancel_done.html"

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_management.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_management.py
@@ -14,7 +14,7 @@ class TestManageAccountView(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = user_factories.UserFactory()
-        cls.manage_account_url = reverse("hidp_accounts:manage_account")
+        cls.manage_account_url = reverse("hidp_account_management:manage_account")
 
     def test_login_required(self):
         """Anonymous users should be redirected to the login page."""
@@ -38,7 +38,7 @@ class TestEditAccountView(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = user_factories.UserFactory()
-        cls.edit_account_url = reverse("hidp_accounts:edit_account")
+        cls.edit_account_url = reverse("hidp_account_management:edit_account")
 
     def test_login_required(self):
         """Anonymous users should be redirected to the login page."""
@@ -79,7 +79,9 @@ class TestEditAccountView(TestCase):
         self.assertEqual(self.user.last_name, "Name")
 
         # Success message should be displayed
-        self.assertRedirects(response, reverse("hidp_accounts:edit_account_done"))
+        self.assertRedirects(
+            response, reverse("hidp_account_management:edit_account_done")
+        )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/edit_account_done.html"
         )
@@ -89,7 +91,7 @@ class TestPasswordChangeView(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = user_factories.UserFactory()
-        cls.change_password_url = reverse("hidp_accounts:change_password")
+        cls.change_password_url = reverse("hidp_account_management:change_password")
 
     def test_login_required(self):
         """Anonymous users should be redirected to the login page."""
@@ -106,7 +108,7 @@ class TestPasswordChangeView(TestCase):
         self.user.save()
         self.client.force_login(self.user)
         response = self.client.get(self.change_password_url, follow=True)
-        self.assertRedirects(response, reverse("hidp_accounts:set_password"))
+        self.assertRedirects(response, reverse("hidp_account_management:set_password"))
 
     def test_get(self):
         """The password change page should be displayed for authenticated users."""
@@ -137,7 +139,9 @@ class TestPasswordChangeView(TestCase):
         self.assertTrue(self.user.check_password("new_password"))
 
         # Redirect to the success page
-        self.assertRedirects(response, reverse("hidp_accounts:change_password_done"))
+        self.assertRedirects(
+            response, reverse("hidp_account_management:change_password_done")
+        )
         self.assertTemplateUsed("hidp/accounts/management/password_change_done.html")
 
         # Changed password mail should be sent
@@ -166,7 +170,7 @@ class TestSetPasswordView(TestCase):
         cls.user = user_factories.UserFactory()
         cls.user.set_unusable_password()
         cls.user.save()
-        cls.set_password_url = reverse("hidp_accounts:set_password")
+        cls.set_password_url = reverse("hidp_account_management:set_password")
 
     def test_login_required(self):
         """Anonymous users should be redirected to the login page."""
@@ -182,7 +186,9 @@ class TestSetPasswordView(TestCase):
         self.user.save()
         self.client.force_login(self.user)
         response = self.client.get(self.set_password_url, follow=True)
-        self.assertRedirects(response, reverse("hidp_accounts:change_password"))
+        self.assertRedirects(
+            response, reverse("hidp_account_management:change_password")
+        )
 
     def test_get_not_recently_authenticated(self):
         """The must reauthenticate flag should be set to True."""
@@ -229,7 +235,7 @@ class TestSetPasswordView(TestCase):
         self.assertTemplateUsed(response, "hidp/accounts/management/set_password.html")
         self.assertIn("form", response.context)
 
-    def test_change_password(self):
+    def test_set_password(self):
         """The user's password should be set."""
         self.client.force_login(self.user)
         response = self.client.post(
@@ -248,7 +254,9 @@ class TestSetPasswordView(TestCase):
         )
 
         # Redirect to the success page
-        self.assertRedirects(response, reverse("hidp_accounts:set_password_done"))
+        self.assertRedirects(
+            response, reverse("hidp_account_management:set_password_done")
+        )
         self.assertTemplateUsed("hidp/accounts/management/set_change_done.html")
 
         # Changed password mail should be sent

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_recovery.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_recovery.py
@@ -70,7 +70,7 @@ class TestPasswordResetFlow(TestCase):
         self.assertEqual(message.to, [self.user.email])
         self.assertEqual(message.subject, "Set password request")
         self.assertIn(
-            reverse("hidp_accounts:set_password"),
+            reverse("hidp_account_management:set_password"),
             message.body,
         )
         self.assertRedirects(

--- a/project/hidp_sandbox/urls.py
+++ b/project/hidp_sandbox/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     # Project
     path(
         "",
-        RedirectView.as_view(pattern_name="hidp_accounts:manage_account"),
+        RedirectView.as_view(pattern_name="hidp_account_management:manage_account"),
         name="root",
     ),
     path("", include(hidp_urls)),

--- a/project/tests/smoke_tests/test_root.py
+++ b/project/tests/smoke_tests/test_root.py
@@ -7,6 +7,6 @@ class TestRoot(TestCase):
         response = self.client.get("/")
         self.assertRedirects(
             response,
-            reverse("hidp_accounts:manage_account"),
+            reverse("hidp_account_management:manage_account"),
             fetch_redirect_response=False,
         )


### PR DESCRIPTION
Inspired by #240 I decided to move the account management urls into their own module and namespace. That also makes it easier for implementors to "move" these urls elsewhere.