### PR TITLE
Add dedicated pages to display a success message when linking/unlinking an account

### DIFF
--- a/packages/hidp/docs/templates.md
+++ b/packages/hidp/docs/templates.md
@@ -778,12 +778,6 @@ Rendered by the `OIDCLinkedServicesView`.
 `back_url`
 : Link for the cancel button.
 
-`successfully_linked_provider`
-: Name of provider that was successfully linked.
-
-`removed_provider`
-: Name of provider that was successfully removed.
-
 `oidc_error_message`
 : Error message from the OIDC Authentication flow in case something went wrong.
 
@@ -797,8 +791,7 @@ Rendered by the `OIDCLinkedServicesView`.
 
 Rendered by the `OIDCAccountLinkView`.
 
-Redirects to `OIDCLinkedServicesView` after successfully linking the account to the
-OIDC provider.
+Asks the user to confirm that they want to link their account to the OIDC provider.
 
 **Base template**: `base_post_login.html`
 
@@ -821,12 +814,27 @@ OIDC provider.
 `provider_email`
 : The email address retrieved from the OIDC provider.
 
+### account_link_done.html
+
+Rendered by the `OIDCAccountLinkDoneView`.
+
+Shows a message letting the user know that their account has been linked.
+
+**Base template**: `base_post_login.html`
+
+**Context variables**
+
+`provider`
+: The OIDC provider that the user linked their account to.
+
+`back_url`
+: Link back to the linked services page.
+
 ### account_unlink.html
 
 Rendered by the `OIDCAccountUnlinkView`.
 
-Redirects to `OIDCLinkedServicesView` after successfully unlinking the account from the
-OIDC provider.
+Asks the user to confirm that they want to unlink their account from the OIDC provider.
 
 **Base template**: `base_post_login.html`
 
@@ -842,6 +850,22 @@ OIDC provider.
 
 `cancel_url`
 : URL for the cancel button.
+
+### account_unlink_done.html
+
+Rendered by the `OIDCAccountUnlinkDoneView`.
+
+Shows a message letting the user know that their account has been unlinked.
+
+**Base template**: `base_post_login.html`
+
+**Context variables**
+
+`provider`
+: The OIDC provider that the user unlinked their account from.
+
+`back_url`
+: Link back to the linked services page.
 
 ### registration.html
 

--- a/packages/hidp/hidp/federated/oidc_management_urls.py
+++ b/packages/hidp/hidp/federated/oidc_management_urls.py
@@ -36,8 +36,18 @@ urlpatterns = [
         name="link_account",
     ),
     path(
+        "link-account/<str:provider_key>/done/",
+        views.OIDCAccountLinkDoneView.as_view(),
+        name="link_account_done",
+    ),
+    path(
         "unlink-account/<str:provider_key>/",
         views.OIDCAccountUnlinkView.as_view(),
         name="unlink_account",
+    ),
+    path(
+        "unlink-account/<str:provider_key>/done/",
+        views.OIDCAccountUnlinkDoneView.as_view(),
+        name="unlink_account_done",
     ),
 ]

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -315,6 +315,8 @@ msgstr ""
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
 #: hidp/templates/hidp/accounts/management/password_change_done.html
 #: hidp/templates/hidp/accounts/management/set_password_done.html
+#: hidp/templates/hidp/federated/account_link_done.html
+#: hidp/templates/hidp/federated/account_unlink_done.html
 #: hidp/templates/hidp/federated/linked_services.html
 msgid "Back"
 msgstr ""
@@ -668,6 +670,23 @@ msgstr ""
 msgid "You are about to link your %(provider)s account to your existing account."
 msgstr ""
 
+#: hidp/templates/hidp/federated/account_link_done.html
+#: hidp/templates/hidp/federated/account_unlink_done.html
+#: hidp/templates/hidp/federated/linked_services.html
+msgid "Manage linked trusted services"
+msgstr ""
+
+#: hidp/templates/hidp/federated/account_link_done.html
+#: hidp/templates/hidp/federated/account_unlink_done.html
+#: hidp/templates/hidp/federated/linked_services.html
+msgid "Manage your linked trusted services"
+msgstr ""
+
+#: hidp/templates/hidp/federated/account_link_done.html
+#, python-format
+msgid "Successfully linked your %(provider)s account."
+msgstr ""
+
 #: hidp/templates/hidp/federated/account_unlink.html
 #, python-format
 msgid "This will remove the possibility to use your %(provider)s account to log in."
@@ -682,30 +701,13 @@ msgstr ""
 msgid "You are about to unlink your %(provider)s account from your account."
 msgstr ""
 
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Available services"
-msgstr ""
-
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Dismiss"
-msgstr ""
-
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Manage linked trusted services"
-msgstr ""
-
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Manage your linked trusted services"
-msgstr ""
-
-#: hidp/templates/hidp/federated/linked_services.html
-#, python-format
-msgid "Successfully linked your %(provider)s account."
-msgstr ""
-
-#: hidp/templates/hidp/federated/linked_services.html
+#: hidp/templates/hidp/federated/account_unlink_done.html
 #, python-format
 msgid "Successfully unlinked your %(provider)s account."
+msgstr ""
+
+#: hidp/templates/hidp/federated/linked_services.html
+msgid "Available services"
 msgstr ""
 
 #: hidp/templates/hidp/federated/linked_services.html

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -316,6 +316,8 @@ msgstr "Opslaan"
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
 #: hidp/templates/hidp/accounts/management/password_change_done.html
 #: hidp/templates/hidp/accounts/management/set_password_done.html
+#: hidp/templates/hidp/federated/account_link_done.html
+#: hidp/templates/hidp/federated/account_unlink_done.html
 #: hidp/templates/hidp/federated/linked_services.html
 msgid "Back"
 msgstr "Terug"
@@ -669,6 +671,23 @@ msgstr "Dit stelt je in staat om je %(provider)s-account te gebruiken om in te l
 msgid "You are about to link your %(provider)s account to your existing account."
 msgstr "Je staat op het punt je %(provider)s-account te koppelen aan je bestaande account."
 
+#: hidp/templates/hidp/federated/account_link_done.html
+#: hidp/templates/hidp/federated/account_unlink_done.html
+#: hidp/templates/hidp/federated/linked_services.html
+msgid "Manage linked trusted services"
+msgstr "Beheer gekoppelde vertrouwde diensten"
+
+#: hidp/templates/hidp/federated/account_link_done.html
+#: hidp/templates/hidp/federated/account_unlink_done.html
+#: hidp/templates/hidp/federated/linked_services.html
+msgid "Manage your linked trusted services"
+msgstr "Beheer jouw gekoppelde vertrouwde diensten"
+
+#: hidp/templates/hidp/federated/account_link_done.html
+#, python-format
+msgid "Successfully linked your %(provider)s account."
+msgstr "Je %(provider)s-account is nu gekoppeld."
+
 #: hidp/templates/hidp/federated/account_unlink.html
 #, python-format
 msgid "This will remove the possibility to use your %(provider)s account to log in."
@@ -683,31 +702,14 @@ msgstr "Account ontkoppelen"
 msgid "You are about to unlink your %(provider)s account from your account."
 msgstr "Je staat op het punt je %(provider)s-account te ontkoppelen."
 
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Available services"
-msgstr "Beschikbare diensten"
-
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Dismiss"
-msgstr "Sluiten"
-
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Manage linked trusted services"
-msgstr "Beheer gekoppelde vertrouwde diensten"
-
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Manage your linked trusted services"
-msgstr "Beheer jouw gekoppelde vertrouwde diensten"
-
-#: hidp/templates/hidp/federated/linked_services.html
-#, python-format
-msgid "Successfully linked your %(provider)s account."
-msgstr "Je %(provider)s-account is nu gekoppeld."
-
-#: hidp/templates/hidp/federated/linked_services.html
+#: hidp/templates/hidp/federated/account_unlink_done.html
 #, python-format
 msgid "Successfully unlinked your %(provider)s account."
 msgstr "Je %(provider)s-account is nu ontkoppeld."
+
+#: hidp/templates/hidp/federated/linked_services.html
+msgid "Available services"
+msgstr "Beschikbare diensten"
 
 #: hidp/templates/hidp/federated/linked_services.html
 #, python-format

--- a/packages/hidp/hidp/templates/hidp/federated/account_link_done.html
+++ b/packages/hidp/hidp/templates/hidp/federated/account_link_done.html
@@ -1,0 +1,14 @@
+{% extends "hidp/base_post_login.html" %}
+{% load i18n %}
+
+{% block title %}{% translate 'Manage linked trusted services' %}{% endblock %}
+
+{% block main %}
+  <h1>{% translate 'Manage your linked trusted services' %}</h1>
+
+  {% blocktranslate trimmed with provider=provider.name %}
+    Successfully linked your {{ provider }} account.
+  {% endblocktranslate %}
+
+  {% include 'hidp/includes/forms/submit_row.html' with cancel_label=_('Back') cancel_url=back_url %}
+{% endblock %}

--- a/packages/hidp/hidp/templates/hidp/federated/account_unlink_done.html
+++ b/packages/hidp/hidp/templates/hidp/federated/account_unlink_done.html
@@ -1,0 +1,14 @@
+{% extends "hidp/base_post_login.html" %}
+{% load i18n %}
+
+{% block title %}{% translate 'Manage linked trusted services' %}{% endblock %}
+
+{% block main %}
+  <h1>{% translate 'Manage your linked trusted services' %}</h1>
+
+  {% blocktranslate trimmed with provider=provider.name %}
+    Successfully unlinked your {{ provider }} account.
+  {% endblocktranslate %}
+
+  {% include 'hidp/includes/forms/submit_row.html' with cancel_label=_('Back') cancel_url=back_url %}
+{% endblock %}

--- a/packages/hidp/hidp/templates/hidp/federated/linked_services.html
+++ b/packages/hidp/hidp/templates/hidp/federated/linked_services.html
@@ -13,26 +13,7 @@
       </li>
     </ul>
   {% endif %}
-
-  {% if successfully_linked_provider %}
-    <ul>
-      <li>{% blocktranslate trimmed with provider=successfully_linked_provider.name %}
-        Successfully linked your {{ provider }} account.
-      {% endblocktranslate %}
-        <a href="." aria-label="{% translate 'Dismiss' %}">✕</a>
-      </li>
-    </ul>
-
-  {% elif removed_provider %}
-    <ul>
-      <li>{% blocktranslate trimmed with provider=removed_provider.name %}
-        Successfully unlinked your {{ provider }} account.
-      {% endblocktranslate %}
-        <a href="." aria-label="{% translate 'Dismiss' %}">✕</a>
-      </li>
-    </ul>
-  {% endif %}
-
+  
   {% if oidc_linked_providers %}
     <h2>{% translate 'Linked services' %}</h2>
 

--- a/packages/hidp/tests/smoke_tests/test_federated/test_views.py
+++ b/packages/hidp/tests/smoke_tests/test_federated/test_views.py
@@ -677,17 +677,15 @@ class TestOIDCAccountLinkView(OIDCTokenDataTestMixin, TestCase):
         connection = models.OpenIdConnection.objects.filter(user=self.user).first()
         self.assertIsNotNone(connection, msg="Expected connection to be created.")
 
-        # Redirected to linked services page
+        # Redirected to the done page
         self.assertRedirects(
             response,
-            reverse("hidp_oidc_management:linked_services") + "?success=example",
+            reverse(
+                "hidp_oidc_management:link_account_done",
+                kwargs={"provider_key": "example"},
+            ),
         )
-        # Linked services page
-        self.assertInHTML(
-            "Successfully linked your Example account."
-            '<a href="." aria-label="Dismiss">✕</a>',
-            response.content.decode("utf-8"),
-        )
+        self.assertTemplateUsed(response, "hidp/federated/account_link_done.html")
 
 
 class TestOIDCAccountUnlinkView(TestCase):
@@ -731,17 +729,15 @@ class TestOIDCAccountUnlinkView(TestCase):
     def test_post_with_valid_provider(self):
         response = self.client.post(self.url, {"allow_unlink": "on"}, follow=True)
 
-        # Redirected to linked services page
+        # Redirected to the done page
         self.assertRedirects(
             response,
-            reverse("hidp_oidc_management:linked_services") + "?removed=example",
+            reverse(
+                "hidp_oidc_management:unlink_account_done",
+                kwargs={"provider_key": "example"},
+            ),
         )
-        # Linked services page
-        self.assertInHTML(
-            "Successfully unlinked your Example account."
-            '<a href="." aria-label="Dismiss">✕</a>',
-            response.content.decode("utf-8"),
-        )
+        self.assertTemplateUsed(response, "hidp/federated/account_unlink_done.html")
 
     def test_delete_only_login_method(self):
         # Remove the user's password so they can only log in via OIDC


### PR DESCRIPTION
This removes the need for special "success message" section in the OIDC account list page and makes things more "regular"