### PR TITLE
Use the same template to show a message for invalid links

### DIFF
--- a/packages/hidp/docs/templates.md
+++ b/packages/hidp/docs/templates.md
@@ -79,6 +79,16 @@ add anything over the base template and is only provided as an extension point.
 This template extends `base.html` and is used for all post-login pages. It does not
 add anything over the base template and is only provided as an extension point.
 
+### base_invalid_link.html
+
+When a user accesses a page through a link that is no longer valid an error message
+is shown. To customize this message and the layout of the error page on a global basis,
+override this template.
+
+This template extends `base_pre_login.html`. All cases that may result in an invalid
+link also have a dedicated template that extends this template. These templates are
+noted in the per-page documentation below.
+
 ---
 
 ## Inclusion templates
@@ -412,7 +422,7 @@ Rendered by the `EmailChangeRequestSentView`.
 
 ### email_change_confirm.html
 
-Rendered by the `EmailChangeConfirmView`.
+Rendered by the `EmailChangeConfirmView` when accessed with a valid token.
 
 **Base template**: `base_post_login.html`
 
@@ -422,11 +432,6 @@ Rendered by the `EmailChangeConfirmView`.
 
 `form`
 : The email change confirm form, where users need to confirm the change.
-
-`validlink`
-: boolean that indicates the validity of the used token.
-
-If `validlink` is `True` the following context variables are also available:
 
 `already_confirmed_for_this_email`
 : boolean that indicates if the user has already confirmed the change via the
@@ -441,6 +446,12 @@ If `validlink` is `True` the following context variables are also available:
 
 `proposed_email`
 : The proposed new email address.
+
+### email_change_confirm_invalid_link.html
+
+Rendered by the `EmailChangeConfirmView` when accessed with an invalid token.
+
+**Base template**: `base_invalid_link.html`
 
 ### email_change_complete.html
 
@@ -466,18 +477,13 @@ Rendered by the `EmailChangeCompleteView`.
 
 ### email_change_cancel.html
 
-Rendered by the `EmailChangeCancelView`.
+Rendered by the `EmailChangeCancelView` if there is a pending email change request.
 
 **Base template**: `base_post_login.html`
 
 **Form template**: `accounts/forms/email_change_cancel_form.html`
 
 **Context variables**
-
-`validlink`
-: boolean that indicates whether the request can be cancelled.
-
-If `validlink` is `True` the following context variables are also available:
 
 `current_email`
 : The current email address.
@@ -487,6 +493,12 @@ If `validlink` is `True` the following context variables are also available:
 
 `cancel_url`
 : Link for the back button.
+
+### email_change_cancel_invalid_link.html
+
+Rendered by the `EmailChangeCancelView` if there is no pending email change request.
+
+**Base template**: `base_invalid_link.html`
 
 ### email_change_cancel_done.html
 
@@ -613,7 +625,8 @@ Rendered by the `PasswordResetEmailSentView`.
 
 ### password_reset.html
 
-Rendered by the `PasswordResetView`, which is a subclass of Django's `PasswordResetConfirmView`.
+Rendered by the `PasswordResetView` (a subclass of `PasswordResetConfirmView`)
+when accessed with a valid token.
 
 **Base template**: `base_pre_login.html`
 
@@ -624,8 +637,11 @@ Rendered by the `PasswordResetView`, which is a subclass of Django's `PasswordRe
 `form`
 : The password reset form.
 
-`validlink`
-: boolean that indicates the validity of the used token.
+### password_reset_invalid_link.html
+
+Rendered by the `PasswordResetView` when accessed with an invalid token.
+
+**Base template**: `base_invalid_link.html`
 
 ### password_reset_complete.html
 
@@ -681,18 +697,19 @@ in `templates/hidp/accounts/verification`.
 
 ### email_verification_required.html
 
-Rendered by the `EmailVerificationRequiredView`.
+Rendered by the `EmailVerificationRequiredView` when accessed with a valid token.
 
 **Base template**: `base_pre_login.html`
 
-**Context variables**
+### email_verification_required_invalid_link.html
 
-`validlink`
-: boolean that indicates the validity of the used token.
+Rendered by the `EmailVerificationRequiredView` when accessed with an invalid token.
+
+**Base template**: `base_invalid_link.html`
 
 ### verify_email.html
 
-Rendered by the `EmailVerificationView`.
+Rendered by the `EmailVerificationView` when accessed with a valid token.
 
 **Base template**: `base_pre_login.html`
 
@@ -703,8 +720,11 @@ Rendered by the `EmailVerificationView`.
 `form`
 : The email verification form.
 
-`validlink`
-: boolean that indicates the validity of the used token.
+### verify_email_invalid_link.html
+
+Rendered by the `EmailVerificationView` when accessed with an invalid token.
+
+**Base template**: `base_invalid_link.html`
 
 ### email_verification_complete.html
 

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -393,10 +393,6 @@ msgstr ""
 msgid "Cancel email change"
 msgstr ""
 
-#: hidp/templates/hidp/accounts/management/email_change_cancel.html
-msgid "The link you followed is invalid or has expired."
-msgstr ""
-
 #: hidp/templates/hidp/accounts/management/email_change_cancel_done.html
 msgid "Successfully cancelled the email address change."
 msgstr ""
@@ -440,12 +436,6 @@ msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 msgid "Confirm email change"
-msgstr ""
-
-#: hidp/templates/hidp/accounts/management/email_change_confirm.html
-#: hidp/templates/hidp/accounts/verification/email_verification_required.html
-#: hidp/templates/hidp/accounts/verification/verify_email.html
-msgid "The link you followed is invalid. It may have expired or been used already."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
@@ -536,10 +526,6 @@ msgstr ""
 #: hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
 #: hidp/templates/hidp/accounts/recovery/password_reset_request.html
 msgid "Reset password"
-msgstr ""
-
-#: hidp/templates/hidp/accounts/recovery/password_reset.html
-msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_complete.html
@@ -635,15 +621,19 @@ msgid "You need to verify your email address before you can log in."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
-msgid "Log in to your account to receive a new verification email."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/verification/verify_email.html
 msgid "Please fill in your first and last name."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
 msgid "Verify email"
+msgstr ""
+
+#: hidp/templates/hidp/base_invalid_link.html
+msgid "Invalid link"
+msgstr ""
+
+#: hidp/templates/hidp/base_invalid_link.html
+msgid "The link you followed is invalid. It may have expired or been used already."
 msgstr ""
 
 #: hidp/templates/hidp/federated/account_link.html

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -394,10 +394,6 @@ msgstr "Weet je zeker dat je de wijziging van je e-mailadres van %(current_email
 msgid "Cancel email change"
 msgstr "Annuleer e-mailadres wijziging"
 
-#: hidp/templates/hidp/accounts/management/email_change_cancel.html
-msgid "The link you followed is invalid or has expired."
-msgstr "De link die je hebt gevolgd is ongeldig of verlopen."
-
 #: hidp/templates/hidp/accounts/management/email_change_cancel_done.html
 msgid "Successfully cancelled the email address change."
 msgstr "Het wijzigen van je e-mailadres is succesvol geannuleerd."
@@ -442,12 +438,6 @@ msgstr "Bevestig"
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 msgid "Confirm email change"
 msgstr "Bevestig e-mailadres wijziging"
-
-#: hidp/templates/hidp/accounts/management/email_change_confirm.html
-#: hidp/templates/hidp/accounts/verification/email_verification_required.html
-#: hidp/templates/hidp/accounts/verification/verify_email.html
-msgid "The link you followed is invalid. It may have expired or been used already."
-msgstr "De link die je hebt gevolgd is ongeldig. Het kan zijn dat deze is verlopen of al is gebruikt."
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
 msgid "Enter your new email address."
@@ -538,10 +528,6 @@ msgstr "Voer je nieuwe wachtwoord twee keer in, zodat we kunnen verifiëren dat 
 #: hidp/templates/hidp/accounts/recovery/password_reset_request.html
 msgid "Reset password"
 msgstr "Wachtwoord resetten"
-
-#: hidp/templates/hidp/accounts/recovery/password_reset.html
-msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
-msgstr "De link om je wachtwoord te resetten is ongeldig, mogelijk omdat deze al is gebruikt. Vraag een nieuwe aan."
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_complete.html
 msgid "Your password has been set. You may go ahead and log in now."
@@ -636,16 +622,20 @@ msgid "You need to verify your email address before you can log in."
 msgstr "Je moet je e-mailadres verifiëren voordat je kunt inloggen."
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
-msgid "Log in to your account to receive a new verification email."
-msgstr "Log in op je account om een nieuwe verificatie-e-mail te ontvangen."
-
-#: hidp/templates/hidp/accounts/verification/verify_email.html
 msgid "Please fill in your first and last name."
 msgstr "Voer je voor- en achternaam in."
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
 msgid "Verify email"
 msgstr "E-mailadres verifiëren"
+
+#: hidp/templates/hidp/base_invalid_link.html
+msgid "Invalid link"
+msgstr "Ongeldige link"
+
+#: hidp/templates/hidp/base_invalid_link.html
+msgid "The link you followed is invalid. It may have expired or been used already."
+msgstr "De link die je hebt gevolgd is ongeldig. Het kan zijn dat deze is verlopen of al is gebruikt."
 
 #: hidp/templates/hidp/federated/account_link.html
 #: hidp/templates/hidp/federated/account_unlink.html

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel.html
@@ -6,21 +6,15 @@
 {% block main %}
   <h1>{% translate 'Cancel email change' %}</h1>
 
-  {% if not validlink %}
-    <p>{% translate 'The link you followed is invalid or has expired.' %}</p>
+  <p>
+    {% blocktranslate trimmed %}
+      Are you sure you want to cancel changing your email address from {{ current_email }} to {{ proposed_email }}?
+    {% endblocktranslate %}
+  </p>
 
-  {% else %}
-    <p>
-      {% blocktranslate trimmed %}
-        Are you sure you want to cancel changing your email address from {{ current_email }} to {{ proposed_email }}?
-      {% endblocktranslate %}
-    </p>
-
-    <form method="post">
-      {% csrf_token %}
-      {{ form }}
-      {% include 'hidp/includes/forms/submit_row.html' with submit_label=form.fields.allow_cancel.label cancel_url=cancel_url cancel_label=_('Back') %}
-    </form>
-
-  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    {{ form }}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=form.fields.allow_cancel.label cancel_url=cancel_url cancel_label=_('Back') %}
+  </form>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel_invalid_link.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel_invalid_link.html
@@ -1,0 +1,1 @@
+{% extends "hidp/base_invalid_link.html" %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm.html
@@ -4,27 +4,19 @@
 {% block title %}{% translate 'Confirm email change' %}{% endblock %}
 
 {% block main %}
-  {% if validlink %}
-    <h1>{% translate 'Confirm email change' %}</h1>
+  <h1>{% translate 'Confirm email change' %}</h1>
 
-    <p>
-      {% blocktranslate trimmed %}
-        Are you sure you want to change your email address from {{ current_email }} to {{ proposed_email }}?
-      {% endblocktranslate %}
-    </p>
+  <p>
+    {% blocktranslate trimmed %}
+      Are you sure you want to change your email address from {{ current_email }} to {{ proposed_email }}?
+    {% endblocktranslate %}
+  </p>
 
-    <p>{% translate "Please note that changing your email address will also change the username you use to login." %}</p>
+  <p>{% translate "Please note that changing your email address will also change the username you use to login." %}</p>
 
-    <form method="post">
-      {% csrf_token %}
-      {{ form }}
-      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Confirm') %}
-    </form>
-
-  {% else %}
-    <p>
-      {% translate 'The link you followed is invalid. It may have expired or been used already.' %}
-    </p>
-
-  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    {{ form }}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Confirm') %}
+  </form>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm_invalid_link.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm_invalid_link.html
@@ -1,0 +1,1 @@
+{% extends "hidp/base_invalid_link.html" %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset.html
@@ -4,19 +4,13 @@
 {% block title %}{% translate 'Reset password' %}{% endblock %}
 
 {% block main %}
-  {% if validlink %}
-    <p>{% translate "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
+  <p>{% translate "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
 
-    <form method="post">
-      {% csrf_token %}
-      <!-- Hidden text input to assist password managers with updating the stored credentials -->
-      <input hidden autocomplete="username" value="{{ form.user.get_username }}">
-      {{ form }}
-      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Change password') %}
-    </form>
-
-  {% else %}
-    <p>{% translate "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}</p>
-
-  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    <!-- Hidden text input to assist password managers with updating the stored credentials -->
+    <input hidden autocomplete="username" value="{{ form.user.get_username }}">
+    {{ form }}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Change password') %}
+  </form>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_invalid_link.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_invalid_link.html
@@ -1,0 +1,1 @@
+{% extends "hidp/base_invalid_link.html" %}

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_required.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_required.html
@@ -4,26 +4,20 @@
 {% block title %}{% translate 'Verification required' %}{% endblock %}
 
 {% block main %}
-  {% if validlink %}
-    <h1>{% translate 'Verification required' %}</h1>
+  <h1>{% translate 'Verification required' %}</h1>
 
-    <p>{% translate 'You need to verify your email address before you can log in.' %}</p>
+  <p>{% translate 'You need to verify your email address before you can log in.' %}</p>
 
-    <p>
-      {% blocktranslate trimmed %}
-        Please check your email for a message with a verification link. This message may take a few minutes to arrive.
-        If you don't see it, check your spam folder. If you still can't find it, you can request a new verification
-        email.
-      {% endblocktranslate %}
-    </p>
+  <p>
+    {% blocktranslate trimmed %}
+      Please check your email for a message with a verification link. This message may take a few minutes to arrive.
+      If you don't see it, check your spam folder. If you still can't find it, you can request a new verification
+      email.
+    {% endblocktranslate %}
+  </p>
 
-    <form method="post">
-      {% csrf_token %}
-      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Resend verification email') %}
-    </form>
-
-  {% else %}
-    <p>{% translate 'The link you followed is invalid. It may have expired or been used already.' %}</p>
-
-  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Resend verification email') %}
+  </form>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_required_invalid_link.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_required_invalid_link.html
@@ -1,0 +1,1 @@
+{% extends "hidp/base_invalid_link.html" %}

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/verify_email.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/verify_email.html
@@ -4,27 +4,15 @@
 {% block title %}{% translate 'Verify email' %}{% endblock %}
 
 {% block main %}
-  {% if validlink %}
-    <h1>{% translate 'Verify email' %}</h1>
+  <h1>{% translate 'Verify email' %}</h1>
 
-    {% if form.first_name and form.last_name %}
-      <p>{% translate 'Please fill in your first and last name.' %}</p>
-    {% endif %}
-
-    <form method="post">
-      {% csrf_token %}
-      {{ form }}
-      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Verify email') %}
-    </form>
-
-  {% else %}
-    <p>
-      {% translate 'The link you followed is invalid. It may have expired or been used already.' %}
-    </p>
-
-    <p>
-      {% translate 'Log in to your account to receive a new verification email.' %}
-    </p>
-
+  {% if form.first_name and form.last_name %}
+    <p>{% translate 'Please fill in your first and last name.' %}</p>
   {% endif %}
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form }}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Verify email') %}
+  </form>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/verify_email_invalid_link.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/verify_email_invalid_link.html
@@ -1,0 +1,1 @@
+{% extends "hidp/base_invalid_link.html" %}

--- a/packages/hidp/hidp/templates/hidp/base_invalid_link.html
+++ b/packages/hidp/hidp/templates/hidp/base_invalid_link.html
@@ -1,0 +1,10 @@
+{% extends "hidp/base_pre_login.html" %}
+{% load i18n %}
+
+{% block title %}{% translate 'Invalid link' %}{% endblock %}
+
+{% block main %}
+  <h1>{% translate 'Invalid link' %}</h1>
+  
+  <p>{% translate 'The link you followed is invalid. It may have expired or been used already.' %}</p>
+{% endblock %}

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_recovery.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_recovery.py
@@ -138,10 +138,6 @@ class TestPasswordResetFlow(TestCase):
         response = self.client.get(password_reset_url, follow=True)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertTemplateUsed(response, "hidp/accounts/recovery/password_reset.html")
-        self.assertIn("validlink", response.context)
-        self.assertTrue(
-            response.context["validlink"], msg="Expected the link to be valid."
-        )
         self.assertIsInstance(response.context["form"], forms.PasswordResetForm)
 
     def test_post_password_reset_url(self):
@@ -198,7 +194,7 @@ class TestPasswordResetFlow(TestCase):
 
         with self.subTest("The password reset URL is invalid after use."):
             response = self.client.get(password_reset_url, follow=True)
-            self.assertIn("validlink", response.context)
-            self.assertFalse(
-                response.context["validlink"], msg="Expected the link to be invalid."
+            self.assertTemplateUsed(
+                response,
+                "hidp/accounts/recovery/password_reset_invalid_link.html",
             )

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_verification.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_verification.py
@@ -34,17 +34,14 @@ class TestEmailVerificationRequiredView(TestCase):
     def _assert_response(self, response, *, validlink=True):
         """Convenience method to assert the response."""
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertTemplateUsed(
-            response, "hidp/accounts/verification/email_verification_required.html"
-        )
-        self.assertIn("validlink", response.context)
         if validlink:
-            self.assertTrue(
-                response.context["validlink"], msg="Expected the link to be valid."
+            self.assertTemplateUsed(
+                response, "hidp/accounts/verification/email_verification_required.html"
             )
         else:
-            self.assertFalse(
-                response.context["validlink"], msg="Expected the link to be invalid."
+            self.assertTemplateUsed(
+                response,
+                "hidp/accounts/verification/email_verification_required_invalid_link.html",
             )
 
     def test_valid_get(self):
@@ -118,17 +115,13 @@ class TestEmailVerificationView(TestCase):
     def _assert_response(self, response, *, validlink=True):
         """Convenience method to assert the response."""
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertTemplateUsed(
-            response, "hidp/accounts/verification/verify_email.html"
-        )
-        self.assertIn("validlink", response.context)
         if validlink:
-            self.assertTrue(
-                response.context["validlink"], msg="Expected the link to be valid."
+            self.assertTemplateUsed(
+                response, "hidp/accounts/verification/verify_email.html"
             )
         else:
-            self.assertFalse(
-                response.context["validlink"], msg="Expected the link to be invalid."
+            self.assertTemplateUsed(
+                response, "hidp/accounts/verification/verify_email_invalid_link.html"
             )
 
     def test_valid_get(self):


### PR DESCRIPTION
Removes the conditional rendering in templates (and building context) in favour of a shared template for all invalid links. With the added benefit of giving the implementors the option to more easily customize the behaviour of invalid link pages on a case by base basis.