### PR TITLE
Tweak many messages and their translations

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib.auth import forms as auth_forms
 from django.contrib.auth import get_user_model
+from django.contrib.auth import password_validation as django_password_validation
 from django.db import transaction
 from django.urls import reverse_lazy
 from django.utils import timezone
@@ -290,6 +291,22 @@ class SetPasswordForm(auth_forms.SetPasswordForm):
 
     template_name = "hidp/accounts/management/forms/set_password_form.html"
 
+    # Fields
+    password1 = forms.CharField(
+        label=_("Password"),
+        required=False,
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+        help_text=django_password_validation.password_validators_help_text_html(),
+    )
+    password2 = forms.CharField(
+        label=_("Password confirmation"),
+        required=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+        strip=False,
+        help_text=_("Enter the same password as before, for verification."),
+    )
+
 
 class RateLimitedAuthenticationForm(AuthenticationForm):
     """
@@ -337,8 +354,7 @@ class EmailChangeRequestForm(forms.ModelForm):
         max_length=254,
         widget=forms.EmailInput(),
         help_text=_(
-            "Please note that changing your email address will also"
-            " change the username you use to login."
+            "Please note that this also changes the username you use to sign in."
         ),
     )
     password = forms.CharField(

--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -838,7 +838,7 @@ class ManageAccountView(LoginRequiredMixin, OIDCContextMixin, generic.TemplateVi
             links.append(
                 {
                     "url": reverse("hidp_account_management:set_password"),
-                    "text": _("Set password"),
+                    "text": _("Set a password"),
                 },
             )
 

--- a/packages/hidp/hidp/federated/forms.py
+++ b/packages/hidp/hidp/federated/forms.py
@@ -134,5 +134,5 @@ class OIDCAccountUnlinkForm(forms.Form):
             ).exists()
         )
         if not can_unlink:
-            raise ValidationError(_("You cannot unlink your only way to log in."))
+            raise ValidationError(_("You cannot unlink your only way to sign in."))
         return cleaned_data

--- a/packages/hidp/hidp/federated/views.py
+++ b/packages/hidp/hidp/federated/views.py
@@ -57,7 +57,7 @@ class OIDCContextMixin:
     oidc_error_messages = {
         OIDCError.ACCOUNT_EXISTS: _(
             "You already have an account with this email address."
-            " Please log in to link your account."
+            " Please sign in to link your account."
         ),
         OIDCError.REQUEST_EXPIRED: _(
             "The authentication request has expired. Please try again."
@@ -85,7 +85,7 @@ class OIDCContextMixin:
                     },
                 ),
                 "label": format_lazy(
-                    label or _("Log in with {provider}"),
+                    label or _("Sign in with {provider}"),
                     provider=provider.name,
                 ),
             }

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -11,6 +11,10 @@ msgid "Email"
 msgstr ""
 
 #: hidp/accounts/forms.py
+msgid "Enter the same password as before, for verification."
+msgstr ""
+
+#: hidp/accounts/forms.py
 msgid "I am not a robot"
 msgstr ""
 
@@ -28,6 +32,10 @@ msgid "Password"
 msgstr ""
 
 #: hidp/accounts/forms.py
+msgid "Password confirmation"
+msgstr ""
+
+#: hidp/accounts/forms.py
 msgid "Please confirm that you are not a robot."
 msgstr ""
 
@@ -35,7 +43,7 @@ msgstr ""
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 #: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "Please note that changing your email address will also change the username you use to login."
+msgid "Please note that this also changes the username you use to sign in."
 msgstr ""
 
 #: hidp/accounts/forms.py
@@ -178,7 +186,8 @@ msgstr ""
 #: hidp/templates/hidp/accounts/management/email_change_request.html
 #: hidp/templates/hidp/accounts/management/set_password.html
 #: hidp/templates/hidp/accounts/management/set_password_done.html
-msgid "Set password"
+#: hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
+msgid "Set a password"
 msgstr ""
 
 #: hidp/accounts/views.py
@@ -199,7 +208,7 @@ msgid "Yes, I want to unlink this account"
 msgstr ""
 
 #: hidp/federated/forms.py
-msgid "You cannot unlink your only way to log in."
+msgid "You cannot unlink your only way to sign in."
 msgstr ""
 
 #: hidp/federated/models.py
@@ -224,12 +233,12 @@ msgid "Link with {provider}"
 msgstr ""
 
 #: hidp/federated/views.py
-#, python-brace-format
-msgid "Log in with {provider}"
+msgid "Login failed. Invalid credentials."
 msgstr ""
 
 #: hidp/federated/views.py
-msgid "Login failed. Invalid credentials."
+#, python-brace-format
+msgid "Sign in with {provider}"
 msgstr ""
 
 #: hidp/federated/views.py
@@ -242,11 +251,7 @@ msgid "Unlink from {provider}"
 msgstr ""
 
 #: hidp/federated/views.py
-msgid "You already have an account with this email address. Please log in to link your account."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/login.html
-msgid "Don't have an account yet?"
+msgid "You already have an account with this email address. Please sign in to link your account."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/login.html
@@ -258,17 +263,13 @@ msgid "Forgot your password?"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/login.html
+msgid "No account yet?"
+msgstr ""
+
+#: hidp/templates/hidp/accounts/login.html
 #: hidp/templates/hidp/accounts/recovery/password_reset_complete.html
 #: hidp/templates/hidp/accounts/register.html
-msgid "Log in"
-msgstr ""
-
-#: hidp/templates/hidp/accounts/login.html
-msgid "Log in using a trusted service"
-msgstr ""
-
-#: hidp/templates/hidp/accounts/login.html
-msgid "Log in with username and password"
+msgid "Sign in"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/login.html
@@ -277,15 +278,17 @@ msgstr ""
 msgid "Sign up"
 msgstr ""
 
-#: hidp/templates/hidp/accounts/logout_confirm.html
-#: hidp/templates/hidp/includes/forms/submit_row.html
-msgid "Cancel"
+#: hidp/templates/hidp/accounts/login.html
+msgid "With a trusted service"
+msgstr ""
+
+#: hidp/templates/hidp/accounts/login.html
+msgid "With your email and password"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/logout_confirm.html
-#: hidp/templates/hidp/accounts/management/manage_account.html
-#: hidp/templates/hidp/accounts/register.html
-msgid "Log out"
+#: hidp/templates/hidp/includes/forms/submit_row.html
+msgid "Cancel"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/logout_confirm.html
@@ -295,6 +298,12 @@ msgstr ""
 #: hidp/templates/hidp/accounts/logout_confirm.html
 #, python-format
 msgid "Logout requested by %(application)s"
+msgstr ""
+
+#: hidp/templates/hidp/accounts/logout_confirm.html
+#: hidp/templates/hidp/accounts/management/manage_account.html
+#: hidp/templates/hidp/accounts/register.html
+msgid "Sign out"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/edit_account.html
@@ -329,17 +338,16 @@ msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
 #: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
-msgid "If you didn't request this change, you can cancel the request by visiting the following page:"
+msgid "If you did not make this request, you can cancel it using the following link:"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
-msgid "Please go to the following page and confirm the change:"
+msgid "To confirm this change, use the following link:"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
-#: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
 #, python-format
-msgid "You're receiving this email because you want to change your email address from %(current_email)s to %(proposed_email)s."
+msgid "You requested to change your account email address from %(current_email)s to %(proposed_email)s."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_change_subject.txt
@@ -348,37 +356,38 @@ msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_changed_body.txt
 #, python-format
-msgid "Please note that this means you'll need to use %(proposed_email)s to log in from now on."
+msgid "Please remember to use %(proposed_email)s to sign in from now on. No further action is required."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_changed_body.txt
 #, python-format
-msgid "You're receiving this email because the email address of your account has been changed from %(current_email)s to %(proposed_email)s."
+msgid "Your account email address has been changed from %(current_email)s to %(proposed_email)s."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/email_changed_subject.txt
-msgid "Email address changed"
+msgid "Your account email address has been changed"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/password_changed_body.txt
-msgid "If you did not change your password, please reset your password immediately using this link:"
+msgid "If you did not change your password, please reset your password immediately using the following link:"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/password_changed_body.txt
-msgid "You're receiving this email because your password has been changed."
+#: hidp/templates/hidp/accounts/management/password_change_done.html
+msgid "Your password has been changed."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/password_changed_subject.txt
-msgid "Password changed"
+msgid "Your password has been changed"
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
+msgid "Please change the email address of the other account first, then try again."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
 #, python-format
-msgid "However, %(proposed_email)s is already in use by another account."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
-msgid "If you want to use this email address, you'll need to change the email address of the other account first."
+msgid "You requested to change your account email address from %(current_email)s to %(proposed_email)s. However, you already have an account that uses %(proposed_email)s."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email/proposed_email_exists_subject.txt
@@ -387,16 +396,28 @@ msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_cancel.html
 #, python-format
-msgid "Are you sure you want to cancel changing your email address from %(current_email)s to %(proposed_email)s?"
+msgid "Are you sure you want to cancel the request to change your account email address from %(current_email)s to %(proposed_email)s?"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_cancel.html
 #: hidp/templates/hidp/accounts/management/email_change_cancel_done.html
-msgid "Cancel email change"
+msgid "Cancel email change request"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_cancel_done.html
-msgid "Successfully cancelled the email address change."
+msgid "The request to change your account email address has been successfully canceled."
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email_change_complete.html
+msgid "Please also confirm the change from your current email address."
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email_change_complete.html
+msgid "Please also confirm the change from your new email address."
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email_change_complete.html
+msgid "Please remember to use your new email address to sign in from now on."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
@@ -404,32 +425,24 @@ msgid "Something went wrong"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "Successfully confirmed the change from both your current and new email address."
+msgid "You have confirmed the change from both your current and new email addresses."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "Successfully confirmed the change from your current email address."
+msgid "You have confirmed the change from your current email address."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "Successfully confirmed the change from your new email address."
+msgid "You have confirmed the change from your new email address."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "You also need to confirm the change from your current email."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "You also need to confirm the change from your new email."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "Your email address has been changed."
+msgid "Your account email address has been changed successfully."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 #, python-format
-msgid "Are you sure you want to change your email address from %(current_email)s to %(proposed_email)s?"
+msgid "Are you sure you want to change your account email address from %(current_email)s to %(proposed_email)s?"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
@@ -441,27 +454,33 @@ msgid "Confirm email change"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
-msgid "Enter your new email address."
+msgid "Enter the email address you would like to use for your account."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
-msgid "You cannot change your email address because you do not have a password set."
+msgid "To change your account email address, please set a password first."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
-msgid "You will receive an email on your current and new email address with a link to confirm the change."
+msgid "You will receive an email on both your current and the new email address with a link to confirm this change."
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email_change_request.html
+msgid "Your account does not currently have a password set."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "If you don't receive an email, please make sure you've entered the correct new address, and check your spam folder."
+msgid "Changing your account email address requires confirmation from both your current and new email addresses. Please check your email for a confirmation link."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "Only after you confirmed through both email addresses, your email address will be changed."
+#: hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
+#: hidp/templates/hidp/accounts/verification/email_verification_required.html
+msgid "It may take a few minutes for this email to arrive. If you do not see it, check your spam folder. If you still cannot find it, make sure you entered the correct email address."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "We've emailed you on your current and new email address to confirm the change. You should receive both emails shortly."
+msgid "Your account email address will only be changed after you confirm from both email addresses."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/manage_account.html
@@ -478,8 +497,8 @@ msgstr ""
 msgid "You are currently logged in as %(user)s."
 msgstr ""
 
-#: hidp/templates/hidp/accounts/management/password_change_done.html
-msgid "Your password has been changed."
+#: hidp/templates/hidp/accounts/management/set_password.html
+msgid "Add a password to your account. This will allow you to sign in using your email address and password as well as any linked services."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/set_password.html
@@ -495,32 +514,27 @@ msgid "Your password has been set."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/email/password_reset_body.txt
-msgid "Please go to the following page and choose a new password:"
-msgstr ""
-
-#: hidp/templates/hidp/accounts/recovery/email/password_reset_body.txt
-#: hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
-msgid "You're receiving this email because you requested a password reset."
+msgid "Use the following link to reset your password:"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/email/password_reset_subject.txt
-msgid "Password reset request"
+msgid "Reset your password"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
-msgid "Go to the following page to set a password:"
+msgid "However, your account does not currently have a password set."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
-msgid "However, you haven't set a password yet."
+msgid "Use the following link to set a password:"
 msgstr ""
 
-#: hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
-msgid "Set password request"
+#: hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
+msgid "You requested a link to reset your password."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/password_reset.html
-msgid "Please enter your new password twice so we can verify you typed it in correctly."
+msgid "Please enter your new password twice to ensure you typed it correctly."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/password_reset.html
@@ -531,15 +545,11 @@ msgid "Reset password"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_complete.html
-msgid "Your password has been set. You may go ahead and log in now."
+msgid "Your password has been set. You can now sign in using your new password."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
-msgid "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
-msgid "We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly."
+msgid "Please check your email for a link to reset your password."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_request.html
@@ -547,7 +557,7 @@ msgid "Continue"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_request.html
-msgid "Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgid "Forgotten your password? Enter your email address to receive a link to reset your password."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/register.html
@@ -569,7 +579,7 @@ msgid "Sign up using a trusted service"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/register.html
-msgid "To create a new account, please log out first."
+msgid "To create a new account, please sign out first."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/tos.html
@@ -603,15 +613,11 @@ msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/email_verification_complete.html
 #, python-format
-msgid "You can now <a href=\"%(login_url)s\">log in</a>."
+msgid "You can now <a href=\"%(login_url)s\">sign in</a>."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/email_verification_complete.html
 msgid "Your email address is now verified."
-msgstr ""
-
-#: hidp/templates/hidp/accounts/verification/email_verification_required.html
-msgid "Please check your email for a message with a verification link. This message may take a few minutes to arrive. If you don't see it, check your spam folder. If you still can't find it, you can request a new verification email."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/email_verification_required.html
@@ -623,7 +629,7 @@ msgid "Verification required"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/email_verification_required.html
-msgid "You need to verify your email address before you can log in."
+msgid "You need to verify your email address before you can sign in. Please check your email for a verification link."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
@@ -653,12 +659,12 @@ msgstr ""
 
 #: hidp/templates/hidp/federated/account_link.html
 #, python-format
-msgid "This will allow you to use your %(provider)s account (%(provider_email)s) to log in to your existing account (%(user_email)s)."
+msgid "This will allow you to use your %(provider)s account (%(provider_email)s) to sign in to your existing account (%(user_email)s)."
 msgstr ""
 
 #: hidp/templates/hidp/federated/account_link.html
 #, python-format
-msgid "This will allow you to use your %(provider)s account to log in to your existing account."
+msgid "This will allow you to use your %(provider)s account to sign in to your existing account."
 msgstr ""
 
 #: hidp/templates/hidp/federated/account_link.html
@@ -685,7 +691,7 @@ msgstr ""
 
 #: hidp/templates/hidp/federated/account_unlink.html
 #, python-format
-msgid "This will remove the possibility to use your %(provider)s account to log in."
+msgid "After unlinking, you will no longer be able to use your %(provider)s account to sign in."
 msgstr ""
 
 #: hidp/templates/hidp/federated/account_unlink.html

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -12,6 +12,10 @@ msgid "Email"
 msgstr "E-mailadres"
 
 #: hidp/accounts/forms.py
+msgid "Enter the same password as before, for verification."
+msgstr "Voer ter verificatie nogmaals het wachtwoord in."
+
+#: hidp/accounts/forms.py
 msgid "I am not a robot"
 msgstr "Ik ben geen robot"
 
@@ -29,6 +33,10 @@ msgid "Password"
 msgstr "Wachtwoord"
 
 #: hidp/accounts/forms.py
+msgid "Password confirmation"
+msgstr "Wachtwoordbevestiging"
+
+#: hidp/accounts/forms.py
 msgid "Please confirm that you are not a robot."
 msgstr "Bevestig dat je geen robot bent."
 
@@ -36,8 +44,8 @@ msgstr "Bevestig dat je geen robot bent."
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 #: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "Please note that changing your email address will also change the username you use to login."
-msgstr "Houd er rekening mee dat het wijzigen van je e-mailadres ook je inlognaam verandert."
+msgid "Please note that this also changes the username you use to sign in."
+msgstr "Let op dat hiermee ook je gebruikersnaam voor het inloggen verandert."
 
 #: hidp/accounts/forms.py
 msgid "The new email address is the same as the current email address."
@@ -179,7 +187,8 @@ msgstr "Gekoppelde diensten"
 #: hidp/templates/hidp/accounts/management/email_change_request.html
 #: hidp/templates/hidp/accounts/management/set_password.html
 #: hidp/templates/hidp/accounts/management/set_password_done.html
-msgid "Set password"
+#: hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
+msgid "Set a password"
 msgstr "Wachtwoord instellen"
 
 #: hidp/accounts/views.py
@@ -200,7 +209,7 @@ msgid "Yes, I want to unlink this account"
 msgstr "Ja, ik wil dit account ontkoppelen"
 
 #: hidp/federated/forms.py
-msgid "You cannot unlink your only way to log in."
+msgid "You cannot unlink your only way to sign in."
 msgstr "Je kunt je enige manier om in te loggen niet ontkoppelen."
 
 #: hidp/federated/models.py
@@ -225,13 +234,13 @@ msgid "Link with {provider}"
 msgstr "Koppel met {provider}"
 
 #: hidp/federated/views.py
-#, python-brace-format
-msgid "Log in with {provider}"
-msgstr "Log in met {provider}"
-
-#: hidp/federated/views.py
 msgid "Login failed. Invalid credentials."
 msgstr "Inloggen mislukt. Ongeldige inloggegevens."
+
+#: hidp/federated/views.py
+#, python-brace-format
+msgid "Sign in with {provider}"
+msgstr "Log in met {provider}"
 
 #: hidp/federated/views.py
 msgid "The authentication request has expired. Please try again."
@@ -243,12 +252,8 @@ msgid "Unlink from {provider}"
 msgstr "Ontkoppelen van {provider}"
 
 #: hidp/federated/views.py
-msgid "You already have an account with this email address. Please log in to link your account."
+msgid "You already have an account with this email address. Please sign in to link your account."
 msgstr "Je hebt al een account met dit e-mailadres. Log in om je account te koppelen."
-
-#: hidp/templates/hidp/accounts/login.html
-msgid "Don't have an account yet?"
-msgstr "Heb je nog geen account?"
 
 #: hidp/templates/hidp/accounts/login.html
 msgid "Excessive login attempts have been detected for this account. For your safety, additional security measures are now in place."
@@ -259,35 +264,33 @@ msgid "Forgot your password?"
 msgstr "Wachtwoord vergeten?"
 
 #: hidp/templates/hidp/accounts/login.html
+msgid "No account yet?"
+msgstr "Nog geen account?"
+
+#: hidp/templates/hidp/accounts/login.html
 #: hidp/templates/hidp/accounts/recovery/password_reset_complete.html
 #: hidp/templates/hidp/accounts/register.html
-msgid "Log in"
+msgid "Sign in"
 msgstr "Inloggen"
-
-#: hidp/templates/hidp/accounts/login.html
-msgid "Log in using a trusted service"
-msgstr "Log in met een vertrouwde dienst"
-
-#: hidp/templates/hidp/accounts/login.html
-msgid "Log in with username and password"
-msgstr "Inloggen met gebruikersnaam en wachtwoord"
 
 #: hidp/templates/hidp/accounts/login.html
 #: hidp/templates/hidp/accounts/register.html
 #: hidp/templates/hidp/federated/registration.html
 msgid "Sign up"
-msgstr "Registreer"
+msgstr "Registreren"
+
+#: hidp/templates/hidp/accounts/login.html
+msgid "With a trusted service"
+msgstr "Met een vertrouwde dienst"
+
+#: hidp/templates/hidp/accounts/login.html
+msgid "With your email and password"
+msgstr "Met je e-mailadres en wachtwoord"
 
 #: hidp/templates/hidp/accounts/logout_confirm.html
 #: hidp/templates/hidp/includes/forms/submit_row.html
 msgid "Cancel"
 msgstr "Annuleren"
-
-#: hidp/templates/hidp/accounts/logout_confirm.html
-#: hidp/templates/hidp/accounts/management/manage_account.html
-#: hidp/templates/hidp/accounts/register.html
-msgid "Log out"
-msgstr "Uitloggen"
 
 #: hidp/templates/hidp/accounts/logout_confirm.html
 msgid "Logout"
@@ -297,6 +300,12 @@ msgstr "Uitloggen"
 #, python-format
 msgid "Logout requested by %(application)s"
 msgstr "Uitloggen aangevraagd door %(application)s"
+
+#: hidp/templates/hidp/accounts/logout_confirm.html
+#: hidp/templates/hidp/accounts/management/manage_account.html
+#: hidp/templates/hidp/accounts/register.html
+msgid "Sign out"
+msgstr "Uitloggen"
 
 #: hidp/templates/hidp/accounts/management/edit_account.html
 #: hidp/templates/hidp/accounts/management/edit_account_done.html
@@ -330,18 +339,17 @@ msgstr "Je account is succesvol bijgewerkt."
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
 #: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
-msgid "If you didn't request this change, you can cancel the request by visiting the following page:"
-msgstr "Als je deze wijziging niet hebt aangevraagd, kun je het verzoek annuleren op de volgende pagina:"
+msgid "If you did not make this request, you can cancel it using the following link:"
+msgstr "Als je deze wijziging niet hebt aangevraagd, kun je het met de volgende link annuleren:"
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
-msgid "Please go to the following page and confirm the change:"
-msgstr "Ga naar de volgende pagina en bevestig de wijziging:"
+msgid "To confirm this change, use the following link:"
+msgstr "Gebruik de volgende link om deze wijziging te bevestigen:"
 
 #: hidp/templates/hidp/accounts/management/email/email_change_body.txt
-#: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
 #, python-format
-msgid "You're receiving this email because you want to change your email address from %(current_email)s to %(proposed_email)s."
-msgstr "Je ontvangt deze e-mail omdat je je e-mailadres wilt wijzigen van %(current_email)s naar %(proposed_email)s."
+msgid "You requested to change your account email address from %(current_email)s to %(proposed_email)s."
+msgstr "Je wilt het e-mailadres van je account wijzigen van %(current_email)s naar %(proposed_email)s."
 
 #: hidp/templates/hidp/accounts/management/email/email_change_subject.txt
 msgid "Confirm your email change request"
@@ -349,38 +357,39 @@ msgstr "Bevestig je verzoek om je e-mailadres te wijzigen"
 
 #: hidp/templates/hidp/accounts/management/email/email_changed_body.txt
 #, python-format
-msgid "Please note that this means you'll need to use %(proposed_email)s to log in from now on."
-msgstr "Houd er rekening mee dat je vanaf nu met %(proposed_email)s moet inloggen."
+msgid "Please remember to use %(proposed_email)s to sign in from now on. No further action is required."
+msgstr "Vergeet niet om vanaf nu %(proposed_email)s te gebruiken om in te loggen. Er is verder geen actie vereist."
 
 #: hidp/templates/hidp/accounts/management/email/email_changed_body.txt
 #, python-format
-msgid "You're receiving this email because the email address of your account has been changed from %(current_email)s to %(proposed_email)s."
-msgstr "Je ontvangt deze e-mail omdat het e-mailadres van je account is gewijzigd van %(current_email)s naar %(proposed_email)s."
+msgid "Your account email address has been changed from %(current_email)s to %(proposed_email)s."
+msgstr "Het e-mailadres van je account is gewijzigd van %(current_email)s naar %(proposed_email)s."
 
 #: hidp/templates/hidp/accounts/management/email/email_changed_subject.txt
-msgid "Email address changed"
-msgstr "E-mailadres is gewijzigd"
+msgid "Your account email address has been changed"
+msgstr "Het e-mailadres van je account is gewijzigd"
 
 #: hidp/templates/hidp/accounts/management/email/password_changed_body.txt
-msgid "If you did not change your password, please reset your password immediately using this link:"
-msgstr "Als je dit niet zelf hebt gedaan, wijzig dan meteen je wachtwoord met de volgende link:"
+msgid "If you did not change your password, please reset your password immediately using the following link:"
+msgstr "Als je je wachtwoord niet hebt gewijzigd, stel dan onmiddellijk een nieuw wachtwoord in met de volgende link:"
 
 #: hidp/templates/hidp/accounts/management/email/password_changed_body.txt
-msgid "You're receiving this email because your password has been changed."
-msgstr "Je ontvangt deze e-mail omdat je wachtwoord is gewijzigd."
+#: hidp/templates/hidp/accounts/management/password_change_done.html
+msgid "Your password has been changed."
+msgstr "Je wachtwoord is gewijzigd."
 
 #: hidp/templates/hidp/accounts/management/email/password_changed_subject.txt
-msgid "Password changed"
-msgstr "Je wachtwoord is gewijzigd."
+msgid "Your password has been changed"
+msgstr "Je wachtwoord is gewijzigd"
+
+#: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
+msgid "Please change the email address of the other account first, then try again."
+msgstr "Wijzig eerst het e-mailadres van het andere account en probeer het dan opnieuw."
 
 #: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
 #, python-format
-msgid "However, %(proposed_email)s is already in use by another account."
-msgstr "Echter, %(proposed_email)s is al in gebruik door een ander account."
-
-#: hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
-msgid "If you want to use this email address, you'll need to change the email address of the other account first."
-msgstr "Als je dit e-mailadres wilt gebruiken, moet je eerst het e-mailadres van het andere account wijzigen."
+msgid "You requested to change your account email address from %(current_email)s to %(proposed_email)s. However, you already have an account that uses %(proposed_email)s."
+msgstr "Je wilt het e-mailadres van je account wijzigen van %(current_email)s naar %(proposed_email)s. Je hebt echter al een account met %(proposed_email)s."
 
 #: hidp/templates/hidp/accounts/management/email/proposed_email_exists_subject.txt
 msgid "Email change request"
@@ -388,50 +397,54 @@ msgstr "E-mailadres wijziging"
 
 #: hidp/templates/hidp/accounts/management/email_change_cancel.html
 #, python-format
-msgid "Are you sure you want to cancel changing your email address from %(current_email)s to %(proposed_email)s?"
-msgstr "Weet je zeker dat je de wijziging van je e-mailadres van %(current_email)s naar %(proposed_email)s wilt annuleren?"
+msgid "Are you sure you want to cancel the request to change your account email address from %(current_email)s to %(proposed_email)s?"
+msgstr "Weet je zeker dat je het verzoek om het e-mailadres van je account van %(current_email)s naar %(proposed_email)s te wijzigen wilt annuleren?"
 
 #: hidp/templates/hidp/accounts/management/email_change_cancel.html
 #: hidp/templates/hidp/accounts/management/email_change_cancel_done.html
-msgid "Cancel email change"
-msgstr "Annuleer e-mailadres wijziging"
+msgid "Cancel email change request"
+msgstr "Annuleer verzoek om e-mailadres te wijzigen"
 
 #: hidp/templates/hidp/accounts/management/email_change_cancel_done.html
-msgid "Successfully cancelled the email address change."
-msgstr "Het wijzigen van je e-mailadres is succesvol geannuleerd."
+msgid "The request to change your account email address has been successfully canceled."
+msgstr "Het verzoek om het e-mailadres van je account te wijzigen is succesvol geannuleerd."
+
+#: hidp/templates/hidp/accounts/management/email_change_complete.html
+msgid "Please also confirm the change from your current email address."
+msgstr "Bevestig ook de wijziging vanaf je huidige e-mailadres."
+
+#: hidp/templates/hidp/accounts/management/email_change_complete.html
+msgid "Please also confirm the change from your new email address."
+msgstr "Bevestig ook de wijziging vanaf je nieuwe e-mailadres."
+
+#: hidp/templates/hidp/accounts/management/email_change_complete.html
+msgid "Please remember to use your new email address to sign in from now on."
+msgstr "Vergeet niet om vanaf nu je nieuwe e-mailadres te gebruiken om in te loggen."
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
 msgid "Something went wrong"
 msgstr "Er ging iets fout"
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "Successfully confirmed the change from both your current and new email address."
-msgstr "De wijziging is succesvol bevestigd vanaf zowel je huidige als je nieuwe e-mailadres."
+msgid "You have confirmed the change from both your current and new email addresses."
+msgstr "Je hebt de wijziging bevestigd vanaf zowel je huidige als je nieuwe e-mailadres."
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "Successfully confirmed the change from your current email address."
-msgstr "De wijziging is succesvol bevestigd vanaf je huidige e-mailadres."
+msgid "You have confirmed the change from your current email address."
+msgstr "Je hebt de wijziging bevestigd vanaf je huidige e-mailadres."
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "Successfully confirmed the change from your new email address."
-msgstr "De wijziging is succesvol bevestigd vanaf je nieuwe e-mailadres."
+msgid "You have confirmed the change from your new email address."
+msgstr "Je hebt de wijziging bevestigd vanaf je nieuwe e-mailadres."
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "You also need to confirm the change from your current email."
-msgstr "Je moet de wijziging ook bevestigen vanaf je huidige e-mailadres."
-
-#: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "You also need to confirm the change from your new email."
-msgstr "Je moet de wijziging ook bevestigen vanaf je nieuwe e-mailadres."
-
-#: hidp/templates/hidp/accounts/management/email_change_complete.html
-msgid "Your email address has been changed."
-msgstr "Je e-mailadres is gewijzigd."
+msgid "Your account email address has been changed successfully."
+msgstr "Het e-mailadres van je account is succesvol gewijzigd."
 
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 #, python-format
-msgid "Are you sure you want to change your email address from %(current_email)s to %(proposed_email)s?"
-msgstr "Weet je zeker dat je je e-mailadres wilt wijzigen van %(current_email)s naar %(proposed_email)s?"
+msgid "Are you sure you want to change your account email address from %(current_email)s to %(proposed_email)s?"
+msgstr "Weet je zeker dat je het e-mailadres van je account wilt wijzigen van %(current_email)s naar %(proposed_email)s?"
 
 #: hidp/templates/hidp/accounts/management/email_change_confirm.html
 msgid "Confirm"
@@ -442,28 +455,34 @@ msgid "Confirm email change"
 msgstr "Bevestig e-mailadres wijziging"
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
-msgid "Enter your new email address."
-msgstr "Voer je nieuwe e-mailadres in."
+msgid "Enter the email address you would like to use for your account."
+msgstr "Voer het e-mailadres in dat je voor je account wilt gebruiken."
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
-msgid "You cannot change your email address because you do not have a password set."
-msgstr "Je kan je e-mailadres niet wijzigen, omdat je geen wachtwoord hebt ingesteld."
+msgid "To change your account email address, please set a password first."
+msgstr "Stel eerst een wachtwoord in om het e-mailadres van je account te kunnen wijzigen."
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
-msgid "You will receive an email on your current and new email address with a link to confirm the change."
-msgstr "Je ontvangt een e-mail op zowel je huidige als je nieuwe e-mailadres met een link om de wijziging te bevestigen."
+msgid "You will receive an email on both your current and the new email address with a link to confirm this change."
+msgstr "Je ontvangt een e-mail op zowel je huidige als het nieuwe e-mailadres met een link om de wijziging te bevestigen."
+
+#: hidp/templates/hidp/accounts/management/email_change_request.html
+msgid "Your account does not currently have a password set."
+msgstr "Er is momenteel geen wachtwoord ingesteld voor je account."
 
 #: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "If you don't receive an email, please make sure you've entered the correct new address, and check your spam folder."
-msgstr "Als je geen e-mail ontvangt, controleer dan of je het nieuwe adres correct hebt ingevoerd. Controleer ook je spam."
+msgid "Changing your account email address requires confirmation from both your current and new email addresses. Please check your email for a confirmation link."
+msgstr "Om het e-mailadres van je account te wijzigen moet je bevestigen vanaf zowel je huidige als het nieuwe e-mailadres. Check je e-mail voor een bevestigingslink."
 
 #: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "Only after you confirmed through both email addresses, your email address will be changed."
-msgstr "Pas op het moment dat je via beide e-mailadressen hebt bevestigd, zal je e-mailadres worden gewijzigd."
+#: hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
+#: hidp/templates/hidp/accounts/verification/email_verification_required.html
+msgid "It may take a few minutes for this email to arrive. If you do not see it, check your spam folder. If you still cannot find it, make sure you entered the correct email address."
+msgstr "Het kan een paar minuten duren voordat deze e-mail aankomt. Als je de e-mail niet ziet, controleer dan je spam folder. Als je de e-mail nog steeds niet kunt vinden, controleer dan of je het juiste e-mailadres hebt ingevoerd."
 
 #: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "We've emailed you on your current and new email address to confirm the change. You should receive both emails shortly."
-msgstr "We hebben je een e-mail gestuurd naar zowel je huidige als je nieuwe e-mailadres om de wijziging te bevestigen. Deze zul je deze snel ontvangen."
+msgid "Your account email address will only be changed after you confirm from both email addresses."
+msgstr "Het e-mailadres van je account wordt pas gewijzigd nadat je vanaf beide e-mailadressen hebt bevestigd."
 
 #: hidp/templates/hidp/accounts/management/manage_account.html
 msgid "Manage account"
@@ -479,9 +498,9 @@ msgstr "Beheer je accountinformatie"
 msgid "You are currently logged in as %(user)s."
 msgstr "Je bent momenteel ingelogd als %(user)s."
 
-#: hidp/templates/hidp/accounts/management/password_change_done.html
-msgid "Your password has been changed."
-msgstr "Je wachtwoord is gewijzigd."
+#: hidp/templates/hidp/accounts/management/set_password.html
+msgid "Add a password to your account. This will allow you to sign in using your email address and password as well as any linked services."
+msgstr "Stel een wachtwoord in voor je account. Hiermee kun je inloggen met je e-mailadres en wachtwoord, evenals met eventuele gekoppelde diensten."
 
 #: hidp/templates/hidp/accounts/management/set_password.html
 msgid "For your security, you need to re-authenticate via a linked service before you can set a password."
@@ -496,60 +515,51 @@ msgid "Your password has been set."
 msgstr "Je wachtwoord is ingesteld."
 
 #: hidp/templates/hidp/accounts/recovery/email/password_reset_body.txt
-msgid "Please go to the following page and choose a new password:"
-msgstr "Ga naar de volgende pagina en kies een nieuw wachtwoord:"
-
-#: hidp/templates/hidp/accounts/recovery/email/password_reset_body.txt
-#: hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
-msgid "You're receiving this email because you requested a password reset."
-msgstr "Je ontvangt deze e-mail omdat je wachtwoord reset hebt aangevraagd."
+msgid "Use the following link to reset your password:"
+msgstr "Gebruik de volgende link om een wachtwoord opnieuw in te stellen:"
 
 #: hidp/templates/hidp/accounts/recovery/email/password_reset_subject.txt
-msgid "Password reset request"
-msgstr "Verzoek tot wachtwoord reset"
+msgid "Reset your password"
+msgstr "Je wachtwoord opnieuw instellen"
 
 #: hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
-msgid "Go to the following page to set a password:"
-msgstr "Ga naar de volgende pagina om een wachtwoord in te stellen:"
+msgid "However, your account does not currently have a password set."
+msgstr "Je account heeft alleen nog geen wachtwoord."
 
 #: hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
-msgid "However, you haven't set a password yet."
-msgstr "Je hebt alleen nog geen wachtwoord ingesteld."
+msgid "Use the following link to set a password:"
+msgstr "Gebruik de volgende link om een wachtwoord in te stellen:"
 
-#: hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
-msgid "Set password request"
-msgstr "Verzoek om een wachtwoord in te stellen"
+#: hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
+msgid "You requested a link to reset your password."
+msgstr "Je hebt een link aangevraagd om je wachtwoord opnieuw in te stellen."
 
 #: hidp/templates/hidp/accounts/recovery/password_reset.html
-msgid "Please enter your new password twice so we can verify you typed it in correctly."
-msgstr "Voer je nieuwe wachtwoord twee keer in, zodat we kunnen verifiëren dat je het correct hebt ingevoerd."
+msgid "Please enter your new password twice to ensure you typed it correctly."
+msgstr "Voer je nieuwe wachtwoord twee keer in om er zeker van te zijn dat je het correct hebt ingevoerd."
 
 #: hidp/templates/hidp/accounts/recovery/password_reset.html
 #: hidp/templates/hidp/accounts/recovery/password_reset_complete.html
 #: hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
 #: hidp/templates/hidp/accounts/recovery/password_reset_request.html
 msgid "Reset password"
-msgstr "Wachtwoord resetten"
+msgstr "Wachtwoord opnieuw instellen"
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_complete.html
-msgid "Your password has been set. You may go ahead and log in now."
-msgstr "Je wachtwoord is ingesteld. Je kunt nu inloggen."
+msgid "Your password has been set. You can now sign in using your new password."
+msgstr "Je wachtwoord is ingesteld. Je kunt nu inloggen met je nieuwe wachtwoord."
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
-msgid "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder."
-msgstr "Als je geen e-mail ontvangt, controleer dan of je het adres hebt ingevoerd waarmee je je hebt geregistreerd. Controleer ook je spam."
-
-#: hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
-msgid "We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly."
-msgstr "We hebben je een e-mail gestuurd met instructies voor het opnieuw instellen van je wachtwoord. Als er een account bestaat met het door jou ingevoerde e-mailadres zul je deze snel ontvangen."
+msgid "Please check your email for a link to reset your password."
+msgstr "Check je e-mail voor een link om je wachtwoord opnieuw in te stellen."
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_request.html
 msgid "Continue"
 msgstr "Verder"
 
 #: hidp/templates/hidp/accounts/recovery/password_reset_request.html
-msgid "Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one."
-msgstr "Wachtwoord vergeten? Voer hieronder je e-mailadres in, dan sturen we je instructies om een nieuw wachtwoord in te stellen."
+msgid "Forgotten your password? Enter your email address to receive a link to reset your password."
+msgstr "Wachtwoord vergeten? Voer je e-mailadres om een link te ontvangen waarmee je je wachtwoord opnieuw kunt instellen."
 
 #: hidp/templates/hidp/accounts/register.html
 msgid "Already have an account?"
@@ -567,10 +577,10 @@ msgstr "Maak een nieuw account"
 
 #: hidp/templates/hidp/accounts/register.html
 msgid "Sign up using a trusted service"
-msgstr "Registreer met een vertrouwde dienst"
+msgstr "Registreren met een vertrouwde dienst"
 
 #: hidp/templates/hidp/accounts/register.html
-msgid "To create a new account, please log out first."
+msgid "To create a new account, please sign out first."
 msgstr "Om een nieuw account aan te maken moet je eerst uitloggen."
 
 #: hidp/templates/hidp/accounts/tos.html
@@ -604,16 +614,12 @@ msgstr "Verificatie voltooid"
 
 #: hidp/templates/hidp/accounts/verification/email_verification_complete.html
 #, python-format
-msgid "You can now <a href=\"%(login_url)s\">log in</a>."
+msgid "You can now <a href=\"%(login_url)s\">sign in</a>."
 msgstr "Je kunt nu <a href=\"%(login_url)s\">inloggen</a>."
 
 #: hidp/templates/hidp/accounts/verification/email_verification_complete.html
 msgid "Your email address is now verified."
 msgstr "Je e-mailadres is nu geverifieerd."
-
-#: hidp/templates/hidp/accounts/verification/email_verification_required.html
-msgid "Please check your email for a message with a verification link. This message may take a few minutes to arrive. If you don't see it, check your spam folder. If you still can't find it, you can request a new verification email."
-msgstr "Check of je een e-mail met een verificatielink hebt ontvangen. Het kan een paar minuten duren voordat deze verificatie-e-mail aankomt. Als je de e-mail niet ziet, controleer dan je spam folder. Als je de e-mail nog steeds niet kunt vinden, kun je een nieuwe verificatie-e-mail aanvragen."
 
 #: hidp/templates/hidp/accounts/verification/email_verification_required.html
 msgid "Resend verification email"
@@ -624,8 +630,8 @@ msgid "Verification required"
 msgstr "Verificatie vereist"
 
 #: hidp/templates/hidp/accounts/verification/email_verification_required.html
-msgid "You need to verify your email address before you can log in."
-msgstr "Je moet je e-mailadres verifiëren voordat je kunt inloggen."
+msgid "You need to verify your email address before you can sign in. Please check your email for a verification link."
+msgstr "Je moet je e-mailadres verifiëren voordat je kunt inloggen. Check je e-mail voor een verificatielink."
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
 msgid "Please fill in your first and last name."
@@ -654,12 +660,12 @@ msgstr "Account koppelen"
 
 #: hidp/templates/hidp/federated/account_link.html
 #, python-format
-msgid "This will allow you to use your %(provider)s account (%(provider_email)s) to log in to your existing account (%(user_email)s)."
+msgid "This will allow you to use your %(provider)s account (%(provider_email)s) to sign in to your existing account (%(user_email)s)."
 msgstr "Dit stelt je in staat om je %(provider)s-account (%(provider_email)s) te gebruiken om in te loggen op je bestaande account (%(user_email)s)."
 
 #: hidp/templates/hidp/federated/account_link.html
 #, python-format
-msgid "This will allow you to use your %(provider)s account to log in to your existing account."
+msgid "This will allow you to use your %(provider)s account to sign in to your existing account."
 msgstr "Dit stelt je in staat om je %(provider)s-account te gebruiken om in te loggen op je bestaande account."
 
 #: hidp/templates/hidp/federated/account_link.html
@@ -686,8 +692,8 @@ msgstr "Je %(provider)s-account is nu gekoppeld."
 
 #: hidp/templates/hidp/federated/account_unlink.html
 #, python-format
-msgid "This will remove the possibility to use your %(provider)s account to log in."
-msgstr "Dit haalt de mogelijkheid weg om je %(provider)s-account te gebruiken om in te loggen."
+msgid "After unlinking, you will no longer be able to use your %(provider)s account to sign in."
+msgstr "Na het ontkoppelen kun je niet meer met je %(provider)s-account inloggen."
 
 #: hidp/templates/hidp/federated/account_unlink.html
 msgid "Unlink account"

--- a/packages/hidp/hidp/templates/hidp/accounts/login.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/login.html
@@ -1,7 +1,7 @@
 {% extends 'hidp/base_pre_login.html' %}
 {% load i18n %}
 
-{% block title %}{% translate 'Log in' %}{% endblock %}
+{% block title %}{% translate 'Sign in' %}{% endblock %}
 
 {% block main %}
   {% if oidc_error_message %}
@@ -12,7 +12,9 @@
     </ul>
   {% endif %}
 
-  <h1>{% translate 'Log in with username and password' %}</h1>
+  <h1>{% translate 'Sign in' %}</h1>
+
+  <h2>{% translate 'With your email and password' %}</h2>
 
   {% if is_rate_limited %}
     <p>
@@ -26,7 +28,7 @@
   <form method="post">
     {% csrf_token %}
     {{ form }}
-    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Log in') %}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Sign in') %}
   </form>
 
   <p>
@@ -38,7 +40,7 @@
   {% if oidc_login_providers %}
     <hr>
 
-    <h1>{% translate 'Log in using a trusted service' %}</h1>
+    <h2>{% translate 'With a trusted service' %}</h2>
 
     {% include 'hidp/includes/federated/oidc_provider_list.html' with providers=oidc_login_providers next_url=next %}
 
@@ -47,7 +49,7 @@
   <hr>
 
   <p>
-    {% translate "Don't have an account yet?" %}
+    {% translate 'No account yet?' %}
     <a href="{{ register_url }}">{% translate 'Sign up' %}</a>
   </p>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/logout_confirm.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/logout_confirm.html
@@ -11,7 +11,7 @@
           Logout requested by {{ application }}
         {% endblocktranslate %}
       {% else %}
-        {% translate 'Logout' %}
+        {% translate 'Sign out' %}
       {% endif %}
     </h1>
 
@@ -24,7 +24,7 @@
         {% endif %}
       {% endfor %}
 
-      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Log out') submit_name='allow' submit_value='true' cancel_label=_('Cancel') %}
+      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Sign out') submit_name='allow' submit_value='true' cancel_label=_('Cancel') %}
     </form>
 
   {% else %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email/email_change_body.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email/email_change_body.txt
@@ -1,15 +1,15 @@
 {% load i18n %}{% autoescape off %}
 {% blocktranslate trimmed %}
-You're receiving this email because you want to change your email address from {{ current_email }} to {{ proposed_email }}.
+You requested to change your account email address from {{ current_email }} to {{ proposed_email }}.
 {% endblocktranslate %}
 
-{% translate 'Please note that changing your email address will also change the username you use to login.' %}
-
-{% translate 'Please go to the following page and confirm the change:' %}
+{% translate 'To confirm this change, use the following link:' %}
 
 {{ confirmation_url }}
 
-{% translate "If you didn't request this change, you can cancel the request by visiting the following page:" %}
+{% translate 'Please note that this also changes the username you use to sign in.' %}
+
+{% translate 'If you did not make this request, you can cancel it using the following link:' %}
 
 {{ cancel_url }}
 

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email/email_changed_body.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email/email_changed_body.txt
@@ -1,10 +1,10 @@
 {% load i18n %}{% autoescape off %}
 {% blocktranslate trimmed %}
-You're receiving this email because the email address of your account has been changed from {{ current_email }} to {{ proposed_email }}.
+Your account email address has been changed from {{ current_email }} to {{ proposed_email }}.
 {% endblocktranslate %}
 
 {% blocktranslate trimmed %}
-Please note that this means you'll need to use {{ proposed_email }} to log in from now on.
+Please remember to use {{ proposed_email }} to sign in from now on. No further action is required.
 {% endblocktranslate %}
 
 {% endautoescape %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email/email_changed_subject.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email/email_changed_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% translate 'Email address changed' %}
+{% translate 'Your account email address has been changed' %}
 {% endautoescape %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email/password_changed_body.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email/password_changed_body.txt
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}
-{% translate "You're receiving this email because your password has been changed." %}
+{% translate 'Your password has been changed.' %}
 
-{% translate 'If you did not change your password, please reset your password immediately using this link:' %}
+{% translate 'If you did not change your password, please reset your password immediately using the following link:' %}
 
 {{ password_reset_url }}
 

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email/password_changed_subject.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email/password_changed_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% translate 'Password changed' %}
+{% translate 'Your password has been changed' %}
 {% endautoescape %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email/proposed_email_exists_body.txt
@@ -1,15 +1,12 @@
 {% load i18n %}{% autoescape off %}
 {% blocktranslate trimmed %}
-You're receiving this email because you want to change your email address from {{ current_email }} to {{ proposed_email }}.
+You requested to change your account email address from {{ current_email }} to {{ proposed_email }}.
+However, you already have an account that uses {{ proposed_email }}.
 {% endblocktranslate %}
 
-{% blocktranslate trimmed %}
- However, {{ proposed_email }} is already in use by another account.
- {% endblocktranslate %}
+{% translate 'Please change the email address of the other account first, then try again.' %}
 
-{% translate "If you want to use this email address, you'll need to change the email address of the other account first." %}
-
-{% translate "If you didn't request this change, you can cancel the request by visiting the following page:" %}
+{% translate 'If you did not make this request, you can cancel it using the following link:' %}
 
 {{ cancel_url }}
 

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel.html
@@ -1,14 +1,14 @@
 {% extends 'hidp/base_post_login.html' %}
 {% load i18n %}
 
-{% block title %}{% translate 'Cancel email change' %}{% endblock %}
+{% block title %}{% translate 'Cancel email change request' %}{% endblock %}
 
 {% block main %}
-  <h1>{% translate 'Cancel email change' %}</h1>
+  <h1>{% translate 'Cancel email change request' %}</h1>
 
   <p>
     {% blocktranslate trimmed %}
-      Are you sure you want to cancel changing your email address from {{ current_email }} to {{ proposed_email }}?
+      Are you sure you want to cancel the request to change your account email address from {{ current_email }} to {{ proposed_email }}?
     {% endblocktranslate %}
   </p>
 

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel_done.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_cancel_done.html
@@ -1,12 +1,12 @@
 {% extends 'hidp/base_post_login.html' %}
 {% load i18n %}
 
-{% block title %}{% translate 'Cancel email change' %}{% endblock %}
+{% block title %}{% translate 'Cancel email change request' %}{% endblock %}
 
 {% block main %}
-  <h1>{% translate 'Cancel email change' %}</h1>
+  <h1>{% translate 'Cancel email change request' %}</h1>
 
-  <p>{% translate 'Successfully cancelled the email address change.' %}</p>
+  <p>{% translate 'The request to change your account email address has been successfully canceled.' %}</p>
 
   {% include 'hidp/includes/forms/submit_row.html' with cancel_label=_('Back') cancel_url=back_url %}
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_complete.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_complete.html
@@ -7,16 +7,17 @@
   <h1>{% translate 'Change email address' %}</h1>
 
   {% if current_email_confirmation_required %}
-    <p>{% translate 'Successfully confirmed the change from your new email address.' %}</p>
-    <p>{% translate 'You also need to confirm the change from your current email.' %}</p>
+    <p>{% translate 'You have confirmed the change from your new email address.' %}</p>
+    <p>{% translate 'Please also confirm the change from your current email address.' %}</p>
 
   {% elif proposed_email_confirmation_required %}
-    <p>{% translate 'Successfully confirmed the change from your current email address.' %}</p>
-    <p>{% translate 'You also need to confirm the change from your new email.' %}</p>
+    <p>{% translate 'You have confirmed the change from your current email address.' %}</p>
+    <p>{% translate 'Please also confirm the change from your new email address.' %}</p>
 
   {% elif email_change_request_completed %}
-    <p>{% translate 'Successfully confirmed the change from both your current and new email address.' %}</p>
-    <p>{% translate 'Your email address has been changed.' %}</p>
+    <p>{% translate 'You have confirmed the change from both your current and new email addresses.' %}</p>
+    <p>{% translate 'Your account email address has been changed successfully.' %}</p>
+    <p>{% translate 'Please remember to use your new email address to sign in from now on.' %}</p>
 
   {% else %}
     <p>{% translate 'Something went wrong' %}</p>

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_confirm.html
@@ -8,11 +8,11 @@
 
   <p>
     {% blocktranslate trimmed %}
-      Are you sure you want to change your email address from {{ current_email }} to {{ proposed_email }}?
+      Are you sure you want to change your account email address from {{ current_email }} to {{ proposed_email }}?
     {% endblocktranslate %}
   </p>
 
-  <p>{% translate 'Please note that changing your email address will also change the username you use to login.' %}</p>
+  <p>{% translate 'Please note that this also changes the username you use to sign in.' %}</p>
 
   <form method="post">
     {% csrf_token %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request.html
@@ -7,16 +7,17 @@
   <h1>{% translate 'Change email address' %}</h1>
 
   {% if not can_change_email %}
-    <p>{% translate 'You cannot change your email address because you do not have a password set.' %}</p>
+    <p>{% translate 'Your account does not currently have a password set.' %}</p>
     <p>{% translate 'Your password is required to verify your identity.' %}</p>
+    <p>{% translate 'To change your account email address, please set a password first.' %}</p>
 
     <form action="{{ set_password_url }}" method="get">
-      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Set password') cancel_url=cancel_url %}
+      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Set a password') cancel_url=cancel_url %}
     </form>
 
   {% else %}
-    <p>{% translate 'Enter your new email address.' %}</p>
-    <p>{% translate 'You will receive an email on your current and new email address with a link to confirm the change.' %}</p>
+    <p>{% translate 'Enter the email address you would like to use for your account.' %}</p>
+    <p>{% translate 'You will receive an email on both your current and the new email address with a link to confirm this change.' %}</p>
 
     <form method="post">
       {% csrf_token %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request_sent.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/email_change_request_sent.html
@@ -4,10 +4,15 @@
 {% block title %}{% translate 'Change email address' %}{% endblock %}
 
 {% block main %}
-  <p>{% translate "We've emailed you on your current and new email address to confirm the change. You should receive both emails shortly." %}</p>
-  <p>{% translate "If you don't receive an email, please make sure you've entered the correct new address, and check your spam folder." %}</p>
-  <p>{% translate 'Only after you confirmed through both email addresses, your email address will be changed.' %}</p>
-  <p>{% translate 'Please note that changing your email address will also change the username you use to login.' %}</p>
+  <h1>{% translate 'Change email address' %}</h1>
+
+  <p>{% translate 'Changing your account email address requires confirmation from both your current and new email addresses. Please check your email for a confirmation link.' %}</p>
+
+  <p>{% translate 'It may take a few minutes for this email to arrive. If you do not see it, check your spam folder. If you still cannot find it, make sure you entered the correct email address.' %}</p>
+
+  <p>{% translate 'Your account email address will only be changed after you confirm from both email addresses.' %}</p>
+
+  <p>{% translate 'Please note that this also changes the username you use to sign in.' %}</p>
 
   {% include 'hidp/includes/forms/submit_row.html' with cancel_label=_('Back') cancel_url=back_url %}
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/manage_account.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/manage_account.html
@@ -12,7 +12,7 @@
       {% blocktranslate trimmed %}
         You are currently logged in as {{ user }}.
       {% endblocktranslate %}
-      <button type="submit">{% translate 'Log out' %}</button>
+      <button type="submit">{% translate 'Sign out' %}</button>
     </p>
   </form>
 

--- a/packages/hidp/hidp/templates/hidp/accounts/management/set_password.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/set_password.html
@@ -1,10 +1,10 @@
 {% extends 'hidp/base_post_login.html' %}
 {% load i18n %}
 
-{% block title %}{% translate 'Set password' %}{% endblock %}
+{% block title %}{% translate 'Set a password' %}{% endblock %}
 
 {% block main %}
-  <h1>{% translate 'Set password' %}</h1>
+  <h1>{% translate 'Set a password' %}</h1>
 
   {% if must_reauthenticate %}
     <p>{% translate 'For your security, you need to re-authenticate via a linked service before you can set a password.' %}</p>
@@ -20,6 +20,10 @@
     {% include 'hidp/includes/forms/submit_row.html' with cancel_url=cancel_url %}
 
   {% else %}
+    <p>
+      {% translate 'Add a password to your account. This will allow you to sign in using your email address and password as well as any linked services.' %}
+    </p>
+
     <form method="post">
       {% csrf_token %}
       {{ form }}

--- a/packages/hidp/hidp/templates/hidp/accounts/management/set_password_done.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/management/set_password_done.html
@@ -1,10 +1,10 @@
 {% extends 'hidp/base_post_login.html' %}
 {% load i18n %}
 
-{% block title %}{% translate 'Set password' %}{% endblock %}
+{% block title %}{% translate 'Set a password' %}{% endblock %}
 
 {% block main %}
-  <h1>{% translate 'Set password' %}</h1>
+  <h1>{% translate 'Set a password' %}</h1>
 
   <p>{% translate 'Your password has been set.' %}</p>
 

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/email/password_reset_body.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/email/password_reset_body.txt
@@ -1,7 +1,5 @@
 {% load i18n %}{% autoescape off %}
-{% translate "You're receiving this email because you requested a password reset." %}
-
-{% translate 'Please go to the following page and choose a new password:' %}
+{% translate 'Use the following link to reset your password:' %}
 
 {{ password_reset_url }}
 {% endautoescape %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/email/password_reset_subject.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/email/password_reset_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% translate 'Password reset request' %}
+{% translate 'Reset your password' %}
 {% endautoescape %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/email/set_password_body.txt
@@ -1,9 +1,9 @@
 {% load i18n %}{% autoescape off %}
-{% translate "You're receiving this email because you requested a password reset." %}
+{% translate 'You requested a link to reset your password.' %}
 
-{% translate "However, you haven't set a password yet." %}
+{% translate 'However, your account does not currently have a password set.' %}
 
-{% translate 'Go to the following page to set a password:' %}
+{% translate 'Use the following link to set a password:' %}
 
 {{ set_password_url }}
 {% endautoescape %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% translate 'Set password request' %}
+{% translate 'Set a password' %}
 {% endautoescape %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset.html
@@ -6,7 +6,7 @@
 {% block main %}
   <h1>{% translate 'Reset password' %}</h1>
 
-  <p>{% translate 'Please enter your new password twice so we can verify you typed it in correctly.' %}</p>
+  <p>{% translate 'Please enter your new password twice to ensure you typed it correctly.' %}</p>
 
   <form method="post">
     {% csrf_token %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_complete.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_complete.html
@@ -6,7 +6,7 @@
 {% block main %}
   <h1>{% translate 'Reset password' %}</h1>
 
-  <p>{% translate 'Your password has been set. You may go ahead and log in now.' %}</p>
+  <p>{% translate 'Your password has been set. You can now sign in using your new password.' %}</p>
 
-  <p><a href="{{ login_url }}">{% translate 'Log in' %}</a></p>
+  <p><a href="{{ login_url }}">{% translate 'Sign in' %}</a></p>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_email_sent.html
@@ -6,17 +6,7 @@
 {% block main %}
   <h1>{% translate 'Reset password' %}</h1>
 
-  <p>
-    {% blocktranslate trimmed %}
-      We've emailed you instructions for setting your password, if an account exists with the email you entered.
-      You should receive them shortly.
-    {% endblocktranslate %}
-  </p>
+  <p>{% translate 'Please check your email for a link to reset your password.' %}</p>
 
-  <p>
-    {% blocktranslate trimmed %}
-      If you don't receive an email, please make sure you've entered the address you registered with,
-      and check your spam folder.
-    {% endblocktranslate %}
-  </p>
+  <p>{% translate 'It may take a few minutes for this email to arrive. If you do not see it, check your spam folder. If you still cannot find it, make sure you entered the correct email address.' %}<p>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_request.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/recovery/password_reset_request.html
@@ -5,10 +5,10 @@
 
 {% block main %}
   <h1>{% translate 'Reset password' %}</h1>
-  
+
   <p>
     {% blocktranslate trimmed %}
-      Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one.
+      Forgotten your password? Enter your email address to receive a link to reset your password.
     {% endblocktranslate %}
   </p>
 

--- a/packages/hidp/hidp/templates/hidp/accounts/register.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/register.html
@@ -17,14 +17,14 @@
   {% if not can_register %}
     <p>
       {% blocktranslate %}You are currently logged in as {{ user }}.{% endblocktranslate %}
-      {% translate 'To create a new account, please log out first.' %}
+      {% translate 'To create a new account, please sign out first.' %}
     </p>
 
     <form action="{{ logout_url }}" method="post">
       {% csrf_token %}
       <input type="hidden" name="next" value="{{ logout_next_url }}">
       <p>
-        <button type="submit">{% translate 'Log out' %}</button>
+        <button type="submit">{% translate 'Sign out' %}</button>
       </p>
     </form>
 
@@ -53,7 +53,7 @@
 
     <p>
       {% translate 'Already have an account?' %}
-      <a href="{{ login_url }}">{% translate 'Log in' %}</a>
+      <a href="{{ login_url }}">{% translate 'Sign in' %}</a>
     </p>
 
   {% endif %}

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_complete.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_complete.html
@@ -8,6 +8,6 @@
 
   <p>
     {% translate 'Your email address is now verified.' %}
-    {% blocktranslate %}You can now <a href="{{ login_url }}">log in</a>.{% endblocktranslate %}
+    {% blocktranslate %}You can now <a href="{{ login_url }}">sign in</a>.{% endblocktranslate %}
   </p>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_required.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/email_verification_required.html
@@ -6,15 +6,9 @@
 {% block main %}
   <h1>{% translate 'Verification required' %}</h1>
 
-  <p>{% translate 'You need to verify your email address before you can log in.' %}</p>
+  <p>{% translate 'You need to verify your email address before you can sign in. Please check your email for a verification link.' %}</p>
 
-  <p>
-    {% blocktranslate trimmed %}
-      Please check your email for a message with a verification link. This message may take a few minutes to arrive.
-      If you don't see it, check your spam folder. If you still can't find it, you can request a new verification
-      email.
-    {% endblocktranslate %}
-  </p>
+  <p>{% translate 'It may take a few minutes for this email to arrive. If you do not see it, check your spam folder. If you still cannot find it, make sure you entered the correct email address.' %}</p>
 
   <form method="post">
     {% csrf_token %}

--- a/packages/hidp/hidp/templates/hidp/federated/account_link.html
+++ b/packages/hidp/hidp/templates/hidp/federated/account_link.html
@@ -15,13 +15,13 @@
   <p>
     {% if user_email != provider_email %}
       {% blocktranslate trimmed with provider.name as provider %}
-        This will allow you to use your {{ provider }} account ({{ provider_email }}) to log in to
+        This will allow you to use your {{ provider }} account ({{ provider_email }}) to sign in to
         your existing account ({{ user_email }}).
       {% endblocktranslate %}
 
     {% else %}
       {% blocktranslate trimmed with provider.name as provider %}
-        This will allow you to use your {{ provider }} account to log in to your existing account.
+        This will allow you to use your {{ provider }} account to sign in to your existing account.
       {% endblocktranslate %}
 
     {% endif %}

--- a/packages/hidp/hidp/templates/hidp/federated/account_unlink.html
+++ b/packages/hidp/hidp/templates/hidp/federated/account_unlink.html
@@ -14,7 +14,7 @@
 
   <p>
     {% blocktranslate trimmed with provider.name as provider %}
-      This will remove the possibility to use your {{ provider }} account to log in.
+      After unlinking, you will no longer be able to use your {{ provider }} account to sign in.
     {% endblocktranslate %}
 
     {% translate 'Are you sure you want to do this?' %}

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
@@ -47,8 +47,7 @@ class TestEmailChangeRequest(TestCase):
 
         response = self.client.get(self.url)
         self.assertInHTML(
-            "You cannot change your email address because you do not have a"
-            " password set.",
+            "Your account does not currently have a password set.",
             response.content.decode(),
         )
 
@@ -201,12 +200,7 @@ class TestEmailChangeRequest(TestCase):
         )
         self.assertEqual(message.to, ["existing@example.com"])
         self.assertIn(
-            "However, existing@example.com is already in use by another account.",
-            message.body,
-        )
-        self.assertIn(
-            "If you want to use this email address, you'll need to change the "
-            "email address of the other account first.",
+            "However, you already have an account that uses existing@example.com",
             message.body,
         )
         self.assertIn(
@@ -406,11 +400,7 @@ class TestEmailChangeConfirm(TestCase):
             response, "hidp/accounts/management/email_change_complete.html"
         )
         self.assertInHTML(
-            "Successfully confirmed the change from your current email address.",
-            response.content.decode(),
-        )
-        self.assertInHTML(
-            "You also need to confirm the change from your new email.",
+            "Please also confirm the change from your new email address.",
             response.content.decode(),
         )
         self.email_change_request.refresh_from_db()
@@ -436,11 +426,7 @@ class TestEmailChangeConfirm(TestCase):
             response, "hidp/accounts/management/email_change_complete.html"
         )
         self.assertInHTML(
-            "Successfully confirmed the change from your new email address.",
-            response.content.decode(),
-        )
-        self.assertInHTML(
-            "You also need to confirm the change from your current email.",
+            "Please also confirm the change from your current email address.",
             response.content.decode(),
         )
         self.email_change_request.refresh_from_db()
@@ -469,12 +455,7 @@ class TestEmailChangeConfirm(TestCase):
             response, "hidp/accounts/management/email_change_complete.html"
         )
         self.assertInHTML(
-            "Successfully confirmed the change from both your current and new "
-            " email address.",
-            response.content.decode(),
-        )
-        self.assertInHTML(
-            "Your email address has been changed.",
+            "Your account email address has been changed successfully.",
             response.content.decode(),
         )
 
@@ -490,22 +471,12 @@ class TestEmailChangeConfirm(TestCase):
         # Email changed mail should be sent
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
+            "Your account email address has been changed",
             mail.outbox[0].subject,
-            "Email address changed",
         )
         self.assertEqual(
             mail.outbox[0].to,
             ["current@example.com", "newemail@example.com"],
-        )
-        self.assertIn(
-            "You're receiving this email because the email address of your account"
-            " has been changed from current@example.com to newemail@example.com.",
-            mail.outbox[0].body,
-        )
-        self.assertIn(
-            "Please note that this means you'll need to use"
-            " newemail@example.com to log in from now on.",
-            mail.outbox[0].body,
         )
 
     def test_post_invalid_token(self):

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_login.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_login.py
@@ -73,7 +73,7 @@ class TestLogin(TestCase):
         )
         # Verification required page
         self.assertInHTML(
-            "You need to verify your email address before you can log in.",
+            "Verification required",
             response.content.decode("utf-8"),
         )
 

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_management.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_management.py
@@ -148,16 +148,7 @@ class TestPasswordChangeView(TestCase):
         self.assertEqual(1, len(mail.outbox))
         message = mail.outbox[0]
         self.assertEqual(message.to, [self.user.email])
-        self.assertEqual(message.subject, "Password changed")
-        self.assertIn(
-            "You're receiving this email because your password has been changed.",
-            message.body,
-        )
-        self.assertIn(
-            "If you did not change your password, please reset your password"
-            " immediately using this link:",
-            message.body,
-        )
+        self.assertEqual("Your password has been changed", message.subject)
         self.assertIn(
             reverse("hidp_accounts:password_reset_request"),
             message.body,
@@ -263,16 +254,7 @@ class TestSetPasswordView(TestCase):
         self.assertEqual(1, len(mail.outbox))
         message = mail.outbox[0]
         self.assertEqual(message.to, [self.user.email])
-        self.assertEqual(message.subject, "Password changed")
-        self.assertIn(
-            "You're receiving this email because your password has been changed.",
-            message.body,
-        )
-        self.assertIn(
-            "If you did not change your password, please reset your password"
-            " immediately using this link:",
-            message.body,
-        )
+        self.assertEqual("Your password has been changed", message.subject)
         self.assertIn(
             reverse("hidp_accounts:password_reset_request"),
             message.body,

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_recovery.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_recovery.py
@@ -68,7 +68,7 @@ class TestPasswordResetFlow(TestCase):
         self.assertEqual(1, len(mail.outbox))
         message = mail.outbox[0]
         self.assertEqual(message.to, [self.user.email])
-        self.assertEqual(message.subject, "Set password request")
+        self.assertEqual(message.subject, "Set a password")
         self.assertIn(
             reverse("hidp_account_management:set_password"),
             message.body,
@@ -96,7 +96,7 @@ class TestPasswordResetFlow(TestCase):
         self.assertEqual(1, len(mail.outbox))
         message = mail.outbox[0]
         self.assertEqual(message.to, [self.user.email])
-        self.assertEqual(message.subject, "Password reset request")
+        self.assertEqual(message.subject, "Reset your password")
         self.assertRegex(
             message.body,
             # Matches the password reset URL:
@@ -177,16 +177,7 @@ class TestPasswordResetFlow(TestCase):
         self.assertEqual(1, len(mail.outbox))
         message = mail.outbox[0]
         self.assertEqual(message.to, [self.user.email])
-        self.assertEqual(message.subject, "Password changed")
-        self.assertIn(
-            "You're receiving this email because your password has been changed.",
-            message.body,
-        )
-        self.assertIn(
-            "If you did not change your password, please reset your password"
-            " immediately using this link:",
-            message.body,
-        )
+        self.assertEqual("Your password has been changed", message.subject)
         self.assertIn(
             reverse("hidp_accounts:password_reset_request"),
             message.body,

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_signup.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_signup.py
@@ -88,7 +88,7 @@ class TestRegistrationView(TransactionTestCase):
         )
         # Verification required page
         self.assertInHTML(
-            "You need to verify your email address before you can log in.",
+            "Verification required",
             response.content.decode("utf-8"),
         )
 
@@ -163,7 +163,7 @@ class TestRegistrationView(TransactionTestCase):
         )
         # Verification required page
         self.assertInHTML(
-            "You need to verify your email address before you can log in.",
+            "Verification required",
             response.content.decode("utf-8"),
         )
 
@@ -191,7 +191,7 @@ class TestRegistrationView(TransactionTestCase):
         )
         # Verification required page
         self.assertInHTML(
-            "You need to verify your email address before you can log in.",
+            "Verification required",
             response.content.decode("utf-8"),
         )
         # Sends an email notification to the user

--- a/packages/hidp/tests/smoke_tests/test_federated/test_views.py
+++ b/packages/hidp/tests/smoke_tests/test_federated/test_views.py
@@ -302,7 +302,7 @@ class TestOIDCAuthenticationCallbackView(TestCase):
         )
         self.assertInHTML(
             "You already have an account with this email address."
-            " Please log in to link your account.",
+            " Please sign in to link your account.",
             response.content.decode("utf-8"),
         )
 
@@ -428,7 +428,7 @@ class TestOIDCRegistrationView(OIDCTokenDataTestMixin, TestCase):
         )
         # Verification required page
         self.assertInHTML(
-            "You need to verify your email address before you can log in.",
+            "Verification required",
             response.content.decode("utf-8"),
         )
 
@@ -486,7 +486,7 @@ class TestOIDCLoginView(OIDCTokenDataTestMixin, TestCase):
         )
         # Verification required page
         self.assertInHTML(
-            "You need to verify your email address before you can log in.",
+            "Verification required",
             response.content.decode("utf-8"),
         )
 
@@ -751,7 +751,7 @@ class TestOIDCAccountUnlinkView(TestCase):
         self.assertFormError(
             response.context["form"],
             None,
-            "You cannot unlink your only way to log in.",
+            "You cannot unlink your only way to sign in.",
         )
 
     def test_valid_provider_no_connection(self):


### PR DESCRIPTION
I went through the application and all the flows many times and tweaked a bunch of messages to make the terminology more consistent and to streamline the flow.

Note that github has hidden the translations, you'll need to expand them to check those.