### PR TITLE
Use a temporary redirect

### DIFF
--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -160,7 +160,7 @@ class BaseTokenMixin:
         redirect_url = self.request.get_full_path().replace(
             token, self.token_placeholder
         )
-        return HttpResponseRedirect(redirect_url, status=308)
+        return HttpResponseRedirect(redirect_url, status=307)
 
     def get_template_names(self):
         """Return the template names to use for the view."""

--- a/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
+++ b/packages/hidp/tests/smoke_tests/test_accounts/test_email_change.py
@@ -400,7 +400,7 @@ class TestEmailChangeConfirm(TestCase):
         self.assertRedirects(
             response,
             reverse("hidp_account_management:email_change_complete"),
-            status_code=308,
+            status_code=307,
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_complete.html"
@@ -430,7 +430,7 @@ class TestEmailChangeConfirm(TestCase):
         self.assertRedirects(
             response,
             reverse("hidp_account_management:email_change_complete"),
-            status_code=308,
+            status_code=307,
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_complete.html"
@@ -463,7 +463,7 @@ class TestEmailChangeConfirm(TestCase):
         self.assertRedirects(
             response,
             reverse("hidp_account_management:email_change_complete"),
-            status_code=308,
+            status_code=307,
         )
         self.assertTemplateUsed(
             response, "hidp/accounts/management/email_change_complete.html"


### PR DESCRIPTION
This fixes an edge case in the email change flow where clicking both links would persist only one token.

Scenario:

1. I try to change my email address and open both links at the same time. 
2. I confirm the second link
3. I confirm the first link

The link is invalid, because the session only remembers the token of the first link.

4. I open the first link again

The link remains invalid. The browser has remembered the redirect and replaces the url immediately. The token never reaches the server.

---

By using a temporary redirect the token is persisted correctly. However, ideally you should be able to open both links at the same time and both should keep working. This is a bit harder to achieve, so I'm fixing it this way first.