### PR TITLE
Make OpendIdConnection.__str__ more human friendly

### DIFF
--- a/packages/hidp/hidp/federated/models.py
+++ b/packages/hidp/hidp/federated/models.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 from django.db import models
+from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 
 from ..compat.uuid7 import uuid7
+from ..config import oidc_clients
 
 
 class OpenIdConnectionQuerySet(models.QuerySet):
@@ -72,9 +74,13 @@ class OpenIdConnection(models.Model):
         verbose_name_plural = _("OpenID connections")
 
     def __str__(self):
-        return (
-            f"user: {str(self.user_id)!r}"
-            f" provider: {self.provider_key!r}"
-            f" iss: {self.issuer_claim!r}"
-            f" sub: {self.subject_claim!r}"
+        provider = oidc_clients.get_oidc_client_or_none(self.provider_key)
+        provider_name = (
+            provider.name
+            if provider
+            else format_lazy(
+                _("Unknown provider: {provider_key}"),
+                provider_key=self.provider_key,
+            )
         )
+        return f"{provider_name} ({self.subject_claim})"

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -219,6 +219,11 @@ msgstr ""
 msgid "OpenID connections"
 msgstr ""
 
+#: hidp/federated/models.py
+#, python-brace-format
+msgid "Unknown provider: {provider_key}"
+msgstr ""
+
 #: hidp/federated/views.py
 msgid "An unexpected error occurred during authentication. Please try again."
 msgstr ""

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -220,6 +220,11 @@ msgstr "OpenID-koppeling"
 msgid "OpenID connections"
 msgstr "OpenID-koppelingen"
 
+#: hidp/federated/models.py
+#, python-brace-format
+msgid "Unknown provider: {provider_key}"
+msgstr "Onbekende dienst: {provider_key}"
+
 #: hidp/federated/views.py
 msgid "An unexpected error occurred during authentication. Please try again."
 msgstr "Onverwachte fout tijdens authenticatie. Probeer het opnieuw."


### PR DESCRIPTION
Makes it look much nicer in the Django admin, with the added benefit of also making it possible to identify connections for unregistered providers.

<img width="464" alt="Screenshot 2024-12-05 at 11 14 09" src="https://github.com/user-attachments/assets/53d03fe7-09b2-4b50-97b6-b441fe05abaf">
