### PR TITLE
Strip trailing slash from base_url

### DIFF
--- a/packages/hidp/hidp/accounts/mailers.py
+++ b/packages/hidp/hidp/accounts/mailers.py
@@ -37,14 +37,18 @@ class BaseMailer:
 
     def get_recipients(self):
         """Return a list of email addresses to send the email to."""
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError("Method get_recipients must be implemented")
 
     def _get_subject(self, context):
+        if self.subject_template_name is NotImplemented:
+            raise NotImplementedError("Attribute subject_template_name must be set")
         subject = loader.render_to_string(self.subject_template_name, context)
         # Email subject *must not* contain newlines
         return "".join(subject.splitlines())
 
     def _get_body(self, context):
+        if self.email_template_name is NotImplemented:
+            raise NotImplementedError("Attribute email_template_name must be set")
         return loader.render_to_string(self.email_template_name, context)
 
     def _add_optional_html_body(self, email_message, context):

--- a/packages/hidp/tests/unit_tests/test_accounts/test_base_mailer.py
+++ b/packages/hidp/tests/unit_tests/test_accounts/test_base_mailer.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+
+from hidp.accounts import mailers
+
+
+class TestBaseMailer(TestCase):
+    def test_default_context(self):
+        mailer = mailers.BaseMailer(base_url="https://example.com/")
+        self.assertEqual(
+            mailer.get_context(),
+            {
+                "base_url": "https://example.com",
+            },
+        )
+
+    def test_get_recipients(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            mailers.BaseMailer(base_url="https://example.com/").get_recipients()
+        self.assertEqual(
+            cm.exception.args[0], "Method get_recipients must be implemented"
+        )
+
+    def test_send(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            mailers.BaseMailer(base_url="https://example.com/").send()
+        self.assertEqual(
+            cm.exception.args[0], "Attribute subject_template_name must be set"
+        )


### PR DESCRIPTION
Strips trailing slashes from the base_url in templates, this makes it easier (more correct) to append paths to this var in templates (i.e. the result of {% static %}).

I should probably write a test for this, but asking for feedback first.