### PR TITLE
Add a simple explanation to the verify_email.html template

### DIFF
--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -657,7 +657,11 @@ msgid "You need to verify your email address before you can sign in. Please chec
 msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
-msgid "Please fill in your first and last name."
+msgid "To continue, please fill in your first and last name before verifying your email."
+msgstr ""
+
+#: hidp/templates/hidp/accounts/verification/verify_email.html
+msgid "To continue, please verify your email."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -658,8 +658,12 @@ msgid "You need to verify your email address before you can sign in. Please chec
 msgstr "Je moet je e-mailadres verifiëren voordat je kunt inloggen. Check je e-mail voor een verificatielink."
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
-msgid "Please fill in your first and last name."
-msgstr "Voer je voor- en achternaam in."
+msgid "To continue, please fill in your first and last name before verifying your email."
+msgstr "Vul je voor- en achternaam in voordat je je e-mailadres verifieert."
+
+#: hidp/templates/hidp/accounts/verification/verify_email.html
+msgid "To continue, please verify your email."
+msgstr "Verifieer je e-mailadres om verder te gaan."
 
 #: hidp/templates/hidp/accounts/verification/verify_email.html
 msgid "Verify email"

--- a/packages/hidp/hidp/templates/hidp/accounts/verification/verify_email.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/verification/verify_email.html
@@ -7,7 +7,9 @@
   <h1>{% translate 'Verify email' %}</h1>
 
   {% if form.first_name and form.last_name %}
-    <p>{% translate 'Please fill in your first and last name.' %}</p>
+    <p>{% translate 'To continue, please fill in your first and last name before verifying your email.' %}</p>
+  {% else %}
+    <p>{% translate 'To continue, please verify your email.' %}</p>
   {% endif %}
 
   <form method="post">


### PR DESCRIPTION
This PR adds a single line of explanation to the verify email form, otherwise it's just an empty page, see screenshot from 99gram:
<img width="586" alt="Screenshot 2025-01-13 at 11 08 27" src="https://github.com/user-attachments/assets/ebce65b9-f686-4bb1-85d3-85871e1bf3a6" />

This PR fixes GRA-322.