### PR TITLE
Give the QR code a white background, add alt text since it's not a decorative image

### DIFF
--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -929,6 +929,10 @@ msgid "These codes can be used to log in if you lose access to your two-factor d
 msgstr ""
 
 #: hidp/templates/hidp/otp/setup_device.html
+msgid "QR code for setting up two-factor authentication. Scan with your authenticator app."
+msgstr ""
+
+#: hidp/templates/hidp/otp/setup_device.html
 msgid "Scan the QR code"
 msgstr ""
 

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -930,6 +930,10 @@ msgid "These codes can be used to log in if you lose access to your two-factor d
 msgstr "Deze codes kunnen worden gebruikt om in te loggen als je geen toegang meer hebt tot je tweefactorapparaat. Je kunt op elk moment nieuwe codes genereren, maar je kunt slechts één set codes tegelijk hebben."
 
 #: hidp/templates/hidp/otp/setup_device.html
+msgid "QR code for setting up two-factor authentication. Scan with your authenticator app."
+msgstr "QR-code voor het instellen van tweefactorauthenticatie. Scan met je authenticator-app."
+
+#: hidp/templates/hidp/otp/setup_device.html
 msgid "Scan the QR code"
 msgstr "Scan de QR-code"
 

--- a/packages/hidp/hidp/templates/hidp/otp/setup_device.html
+++ b/packages/hidp/hidp/templates/hidp/otp/setup_device.html
@@ -4,13 +4,35 @@
 {% block title %}{% translate 'Two-factor Authentication' %}{% endblock %}
 
 {% block main %}
+  <style>
+    .qr-code-container {
+      padding: 1rem;
+      background-color: white;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .qr-code-image {
+      max-width: 100%;
+      height: auto;
+      width: 200px;
+      aspect-ratio: 1/1;
+    }
+  </style>
+
   <h1>{% translate 'Set up two-factor authentication' %}</h1>
 
   <form method="post">
     {% csrf_token %}
 
     <h2>{% translate 'Scan the QR code' %}</h2>
-    <div><img src="{{ qrcode|safe }}" width="200" height="200" alt="" /></div>
+    <div class="qr-code-container">
+      <img
+        class="qr-code-image"
+        src="{{ qrcode|safe }}"
+        alt="{% translate 'QR code for setting up two-factor authentication. Scan with your authenticator app.' %}"
+      />
+    </div>
 
     {{ form.non_field_errors }}
 


### PR DESCRIPTION
The QR code now has a white background, making sure scanning it works in dark mode as well.

In dark mode it looks as follows:
<img width="730" alt="Screenshot 2025-04-03 at 10 45 01" src="https://github.com/user-attachments/assets/01429fd2-2633-4c6f-8c45-bbf6d648e340" />

