### PR TITLE
Move "forgot password" closer to actual password field, use inline links to improve readability

### DIFF
--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -818,17 +818,14 @@ msgid "Disabling two-factor authentication will make your account less secure."
 msgstr ""
 
 #: hidp/templates/hidp/otp/disable.html hidp/templates/hidp/otp/verify.html
-msgid "If you have lost your device, you can use a recovery code instead."
+#, python-format
+msgid "If you have lost your device, you can <a href=\"%(recovery_code_url)s\">use a recovery code</a> instead."
 msgstr ""
 
 #: hidp/templates/hidp/otp/disable.html
 #: hidp/templates/hidp/otp/disable_recovery_code.html
 #: hidp/templates/hidp/otp/recovery_codes.html
 msgid "Warning"
-msgstr ""
-
-#: hidp/templates/hidp/otp/disable.html hidp/templates/hidp/otp/verify.html
-msgid "use recovery code"
 msgstr ""
 
 #: hidp/templates/hidp/otp/email/configured_body.html

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -819,18 +819,15 @@ msgid "Disabling two-factor authentication will make your account less secure."
 msgstr "Het uitschakelen van tweefactor­authenticatie maakt je account minder veilig."
 
 #: hidp/templates/hidp/otp/disable.html hidp/templates/hidp/otp/verify.html
-msgid "If you have lost your device, you can use a recovery code instead."
-msgstr "Als je je apparaat bent kwijtgeraakt, kun je in plaats daarvan een herstelcode gebruiken."
+#, python-format
+msgid "If you have lost your device, you can <a href=\"%(recovery_code_url)s\">use a recovery code</a> instead."
+msgstr "Als je je apparaat bent kwijtgeraakt, kun je in plaats daarvan <a href=\"%(recovery_code_url)s\">een herstelcode gebruiken</a>."
 
 #: hidp/templates/hidp/otp/disable.html
 #: hidp/templates/hidp/otp/disable_recovery_code.html
 #: hidp/templates/hidp/otp/recovery_codes.html
 msgid "Warning"
 msgstr "Waarschuwing"
-
-#: hidp/templates/hidp/otp/disable.html hidp/templates/hidp/otp/verify.html
-msgid "use recovery code"
-msgstr "gebruik herstelcode"
 
 #: hidp/templates/hidp/otp/email/configured_body.html
 msgid "You've successfully configured two-factor authentication. Please make sure you have stored your recovery codes in a safe place. You can use these codes to access your account if you lose access to your device. You can view your recovery codes by visiting the two-factor authentication settings page:"

--- a/packages/hidp/hidp/templates/hidp/accounts/login.html
+++ b/packages/hidp/hidp/templates/hidp/accounts/login.html
@@ -28,14 +28,15 @@
   <form method="post">
     {% csrf_token %}
     {{ form }}
+
+    <p>
+      <a href="{{ password_reset_url }}">
+        {% translate 'Forgot your password?' %}
+      </a>
+    </p>
+
     {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Sign in') %}
   </form>
-
-  <p>
-    <a href="{{ password_reset_url }}">
-      {% translate 'Forgot your password?' %}
-    </a>
-  </p>
 
   {% if oidc_login_providers %}
     <hr>

--- a/packages/hidp/hidp/templates/hidp/otp/disable.html
+++ b/packages/hidp/hidp/templates/hidp/otp/disable.html
@@ -15,7 +15,8 @@
     {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Disable two-factor authentication') cancel_url=back_url %}
   </form>
 
-  <p>{% translate 'If you have lost your device, you can use a recovery code instead.' %}</p>
-  <p><a href="{% url 'hidp_otp_management:disable-recovery-code' %}">{% translate "use recovery code" %}</a></p>
-
+  <p>
+    {% url 'hidp_otp_management:disable-recovery-code' as recovery_code_url %}
+    {% blocktranslate  %}If you have lost your device, you can <a href="{{ recovery_code_url }}">use a recovery code</a> instead.{% endblocktranslate %}
+  </p>
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/otp/verify.html
+++ b/packages/hidp/hidp/templates/hidp/otp/verify.html
@@ -13,7 +13,9 @@
   {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Verify') %}
   </form>
 
-  <p>{% translate 'If you have lost your device, you can use a recovery code instead.' %}</p>
-  <p><a href="{% url 'hidp_otp:verify-recovery-code' %}">{% translate "use recovery code" %}</a></p>
+  <p>
+    {% url 'hidp_otp:verify-recovery-code' as recovery_code_url %}
+    {% blocktranslate %}If you have lost your device, you can <a href="{{ recovery_code_url }}">use a recovery code</a> instead.{% endblocktranslate %}
+  </p>
 
 {% endblock %}


### PR DESCRIPTION
New location Forgot Password link:

<img width="369" alt="Screenshot 2025-04-24 at 14 34 45" src="https://github.com/user-attachments/assets/bd784613-2da2-4acd-9ec0-5515d9a6c858" />




Inline links:

Before:
<img width="585" alt="Screenshot 2025-04-24 at 14 32 13" src="https://github.com/user-attachments/assets/92ad7494-c8c4-4ffa-bc8b-7b7deb2cb23e" />
After:
<img width="586" alt="Screenshot 2025-04-24 at 14 31 49" src="https://github.com/user-attachments/assets/424ca468-2f9f-4194-9225-1a5e183477ef" />
