### PR TITLE
HIDP-178 Use matrix testing to ensure compatibility with multiple versions of Python and Django

### DIFF
--- a/.github/actions/python-qa/action.yml
+++ b/.github/actions/python-qa/action.yml
@@ -4,6 +4,10 @@ description: Lint, checks & tests
 inputs:
   working-directory:
     description: The working directory to run the commands in
+  python-version:
+    description: The Python version to use
+  django-version:
+    description: The Django version to use as dependency
 
 runs:
   using: composite
@@ -13,10 +17,15 @@ runs:
       uses: ./.github/actions/setup-python
       with:
         working-directory: ${{ inputs.working-directory }}
+        python-version: ${{ inputs.python-version }}
+        django-version: ${{ inputs.django-version }}
 
     - name: Lint, check, test and build (if applicable)
       run: |
         source ~/.venv/bin/activate
+        UV_DJANGO_VERSION=$(uv pip list | sed -nE 's/^django[[:space:]]+([0-9]+\.[0-9]+)\..*/\1/p')
+        echo "Detected uv Django version: $UV_DJANGO_VERSION"
+        echo "Expected Django version: $DJANGO_VERSION"
         make test
       working-directory: ${{ inputs.working-directory }}
       shell: bash

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -4,6 +4,10 @@ description: Setup Python and install dependencies
 inputs:
   working-directory:
     description: The working directory to run the commands in
+  python-version:
+    description: The Python version to use
+  django-version:
+    description: The Django version to use as dependency
 
 runs:
   using: composite
@@ -12,7 +16,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: ${{ inputs.python-version }}
 
     - name: Install system packages (gettext)
       run: |
@@ -28,6 +32,13 @@ runs:
         python -m pip install --root-user-action=ignore -U uv
         echo ::endgroup::
       working-directory: ${{ inputs.working-directory }}
+      shell: bash
+
+    - name: Set Django version
+      run: |
+        echo ::group::Set Django version environment variable
+        echo "DJANGO_VERSION=${{ inputs.django-version }}" >> $GITHUB_ENV
+        echo ::endgroup::
       shell: bash
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,24 @@ on:
 
 jobs:
   test:
-    name: Linting, checks & tests
+    name: Linting, checks & tests (${{ toJSON(matrix) }})
 
     strategy:
       matrix:
-        working-directory:
-          - './packages/hidp'
-          - './project'
+        django-version: ['4.2.0', '5.2.0']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        working-directory: ['./packages/hidp']
+        exclude:
+          - django-version: '4.2.0'
+            python-version: '3.13'
+          - django-version: '5.2.0'
+            python-version: '3.8'
+          - django-version: '5.2.0'
+            python-version: '3.9'
+        include:
+          - working-directory: './project'
+            python-version: '3.12'
+            django-version: '4.2.0'
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -40,10 +51,12 @@ jobs:
         uses: ./.github/actions/python-qa
         with:
           working-directory: ${{ matrix.working-directory }}
+          django-version: ${{ matrix.django-version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Build documentation
         uses: ./.github/actions/build-hidp-docs
-        if: ${{ matrix.working-directory == './packages/hidp' }}
+        if: ${{ matrix.working-directory == './packages/hidp' && matrix.django-version == '4.2.0' && matrix.python-version == '3.12' }}
 
   # Report success/failure
   success:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,20 @@ jobs:
 
     strategy:
       matrix:
-        django-version: ['4.2.0', '5.2.0']
+        django-version: ['4.2', '5.2']
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         working-directory: ['./packages/hidp']
         exclude:
-          - django-version: '4.2.0'
+          - django-version: '4.2'
             python-version: '3.13'
-          - django-version: '5.2.0'
+          - django-version: '5.2'
             python-version: '3.8'
-          - django-version: '5.2.0'
+          - django-version: '5.2'
             python-version: '3.9'
         include:
           - working-directory: './project'
             python-version: '3.12'
-            django-version: '4.2.0'
+            django-version: '4.2'
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build documentation
         uses: ./.github/actions/build-hidp-docs
-        if: ${{ matrix.working-directory == './packages/hidp' && matrix.django-version == '4.2.0' && matrix.python-version == '3.12' }}
+        if: ${{ matrix.working-directory == './packages/hidp' && matrix.django-version == '4.2' && matrix.python-version == '3.12' }}
 
   # Report success/failure
   success:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,11 @@ jobs:
     strategy:
       matrix:
         django-version: ['4.2', '5.2']
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         working-directory: ['./packages/hidp']
         exclude:
           - django-version: '4.2'
             python-version: '3.13'
-          - django-version: '5.2'
-            python-version: '3.8'
           - django-version: '5.2'
             python-version: '3.9'
         include:

--- a/packages/hidp/Makefile
+++ b/packages/hidp/Makefile
@@ -141,6 +141,8 @@ clean:
 ##
 
 ../../var/requirements_frozen.txt:
+	# Pin Django directly to LTS version provided by the test matrix
+	echo 'Django~=${DJANGO_VERSION}.0' >> requirements.txt
 	uv pip compile pyproject.toml --extra oidc_provider -q -o "${@}" --no-annotate --no-header
 	@echo "### Package dependencies :package:" >> ${GITHUB_STEP_SUMMARY}
 	@echo '```' >> ${GITHUB_STEP_SUMMARY}

--- a/packages/hidp/tests/smoke_tests/test_federated/test_views.py
+++ b/packages/hidp/tests/smoke_tests/test_federated/test_views.py
@@ -536,7 +536,7 @@ class TestOIDCLinkedServicesView(TestCase):
         response = self.client.get(self.oidc_linked_services_url)
 
         # No services linked
-        self.assertNotInHTML("Linked services", response.content.decode("utf-8"))
+        self.assertInHTML("Linked services", response.content.decode("utf-8"), count=0)
 
         # List of available services should be displayed
         self.assertInHTML(
@@ -620,7 +620,9 @@ class TestOIDCLinkedServicesView(TestCase):
             )
 
         # No additional services should be available
-        self.assertNotInHTML("Available services", response.content.decode("utf-8"))
+        self.assertInHTML(
+            "Available services", response.content.decode("utf-8"), count=0
+        )
 
     def test_linked_one_service_with_password_set(self):
         self.user.set_password("P@ssw0rd!")

--- a/project/Makefile
+++ b/project/Makefile
@@ -90,6 +90,8 @@ django-checks:
 ##
 
 ../var/requirements_frozen.txt:
+	# Pin Django directly to LTS version provided by the test matrix
+	echo 'Django~=${DJANGO_VERSION}.0' >> requirements.txt
 	uv pip compile requirements.txt -q -o "${@}" --no-annotate --no-header
 	@echo "### Project dependencies :package:" >> ${GITHUB_STEP_SUMMARY}
 	@echo '```' >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
Perhaps there is a more elegant way to use the django-version from the test matrix in the `make install-pipelines` flow. 

`uv pip install -r '../var/requirements_frozen.txt' -r requirements_local.txt Django~=${DJANGO_VERSION}`

Would run into the issue that `hidp` allows `Django>=4.2,<6` which includes `5.0` pre-releases and using `Django~=4.2.0` would result in a conflict, since that identifier does **not** allow pre releases.