### PR TITLE
Add logout option if unable to verify or setup device

### DIFF
--- a/packages/hidp/hidp/otp/utils.py
+++ b/packages/hidp/hidp/otp/utils.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+from django_otp import user_has_device
+
+
+def user_needs_to_verify_otp(user):
+    """
+    This method checks if the device verification is required due to imported
+    middleware in the application settings. 
+    
+    Return True as default, to maintain the current behavior as specified in the 
+    otp middleware.
+
+    Returns:
+        bool: True if otp verification is required for the user, False otherwise.
+    """
+
+    if (
+        "hidp.otp.middleware.OTPRequiredMiddleware"
+    ) in settings.MIDDLEWARE:
+        return True
+    
+    if (
+        "hidp.otp.middleware.OTPSetupRequiredIfStaffUserMiddleware"
+    ) in settings.MIDDLEWARE:
+        return user.is_staff
+    
+    if (
+        "hidp.otp.middleware.OTPVerificationRequiredIfConfiguredMiddleware"
+    ) in settings.MIDDLEWARE:
+        return user_has_device(user)
+    
+    return True

--- a/packages/hidp/hidp/otp/views.py
+++ b/packages/hidp/hidp/otp/views.py
@@ -208,7 +208,7 @@ class OTPSetupDeviceView(RedirectURLMixin, FormView):
             "recovery_codes": "\n".join(
                 self.backup_device.token_set.values_list("token", flat=True)
             ),
-            "back_url": reverse("hidp_otp_management:manage"),
+            "logout_url": reverse("hidp_accounts:logout"),
         }
 
     def form_valid(self, form):
@@ -260,6 +260,12 @@ class VerifyTOTPView(VerifyOTPBase):
     template_name = "hidp/otp/verify.html"
     form_class = VerifyTOTPForm
 
+    def get_context_data(self, **kwargs):
+        context = {
+            "logout_url": reverse("hidp_accounts:logout")
+        }
+        return super().get_context_data() | context | kwargs
+
 
 class VerifyRecoveryCodeView(VerifyOTPBase):
     template_name = "hidp/otp/verify_recovery_code.html"
@@ -271,6 +277,12 @@ class VerifyRecoveryCodeView(VerifyOTPBase):
         self.send_mail()
 
         return result
+
+    def get_context_data(self, **kwargs):
+        context = {
+            "logout_url": reverse("hidp_accounts:logout")
+        }
+        return super().get_context_data() | context | kwargs
 
     def send_mail(self):
         """Notify the user that a recovery code was used."""

--- a/packages/hidp/hidp/otp/views.py
+++ b/packages/hidp/hidp/otp/views.py
@@ -24,6 +24,7 @@ from hidp.otp.devices import (
 )
 from hidp.otp.forms import OTPSetupForm, VerifyStaticTokenForm, VerifyTOTPForm
 from hidp.rate_limit.decorators import rate_limit_default
+from hidp.otp.utils import user_needs_to_verify_otp
 
 from .decorators import otp_exempt
 from .mailers import (
@@ -208,7 +209,9 @@ class OTPSetupDeviceView(RedirectURLMixin, FormView):
             "recovery_codes": "\n".join(
                 self.backup_device.token_set.values_list("token", flat=True)
             ),
-            "logout_url": reverse("hidp_accounts:logout"),
+            "back_url": reverse("hidp_otp_management:manage"),
+            "logout_url": reverse("hidp_accounts:logout") 
+                if user_needs_to_verify_otp(self.request.user) else None,
         }
 
     def form_valid(self, form):

--- a/packages/hidp/hidp/templates/hidp/includes/forms/logout_form.html
+++ b/packages/hidp/hidp/templates/hidp/includes/forms/logout_form.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+{% comment %}
+The logout_url is required for the form action. It is passed in from the view
+that renders this template. If the logout_url is not provided, the form will 
+submit to the current URL, which may not be the intended behavior.
+{% endcomment %}
+
+{% if logout_url %}
+  <form action="{{ logout_url }}" method="post">
+    {% csrf_token %}
+    <input class="secondary" type="submit" value="{{ logout_label|default:_("Sign out") }}" />
+  </form>
+{% endif %}

--- a/packages/hidp/hidp/templates/hidp/includes/forms/logout_form.html
+++ b/packages/hidp/hidp/templates/hidp/includes/forms/logout_form.html
@@ -1,14 +1,16 @@
 {% load i18n %}
-
 {% comment %}
 The logout_url is required for the form action. It is passed in from the view
-that renders this template. If the logout_url is not provided, the form will 
+that renders this template. If the logout_url is not provided, the form will
 submit to the current URL, which may not be the intended behavior.
 {% endcomment %}
-
 {% if logout_url %}
   <form action="{{ logout_url }}" method="post">
     {% csrf_token %}
-    <input class="secondary" type="submit" value="{{ logout_label|default:_("Sign out") }}" />
+    <input
+      class="submit-link"
+      type="submit"
+      value="{{ logout_label|default:_("Sign out") }}"
+    />
   </form>
 {% endif %}

--- a/packages/hidp/hidp/templates/hidp/otp/setup_device.html
+++ b/packages/hidp/hidp/templates/hidp/otp/setup_device.html
@@ -66,6 +66,8 @@
       {{ form.confirm_stored_backup_tokens }}
     </p>
 
-    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Submit') cancel_label=_('Back') cancel_url=back_url %}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Submit') %}
   </form>
+
+  {% include 'hidp/includes/forms/logout_form.html' with logout_label=_('Back') %}
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/otp/setup_device.html
+++ b/packages/hidp/hidp/templates/hidp/otp/setup_device.html
@@ -69,5 +69,9 @@
     {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Submit') %}
   </form>
 
-  {% include 'hidp/includes/forms/logout_form.html' with logout_label=_('Back') %}
+  {% if logout_url %}
+    {% include 'hidp/includes/forms/logout_form.html' with logout_label=_('Back') %}
+  {% elif back_url %}
+    <a href="{{ back_url }}">{% translate 'Back' %}</a>
+  {% endif %}
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/otp/verify.html
+++ b/packages/hidp/hidp/templates/hidp/otp/verify.html
@@ -7,11 +7,13 @@
   <h1>{% translate 'Two-factor authentication' %}</h1>
 
   <form method="post">
-  {% csrf_token %}
-  {{ form }}
+    {% csrf_token %}
+    {{ form }}
 
-  {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Verify') %}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Verify') %}
   </form>
+
+  {% include 'hidp/includes/forms/logout_form.html' with logout_label=_('Back') %}
 
   <p>
     {% url 'hidp_otp:verify-recovery-code' as recovery_code_url %}

--- a/packages/hidp/hidp/templates/hidp/otp/verify_recovery_code.html
+++ b/packages/hidp/hidp/templates/hidp/otp/verify_recovery_code.html
@@ -7,10 +7,12 @@
   <h1>{% translate 'Two-factor authentication' %}</h1>
 
   <form method="post">
-  {% csrf_token %}
-  {{ form }}
+    {% csrf_token %}
+    {{ form }}
 
-  {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Verify') %}
+    {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Verify') %}
   </form>
+
+  {% include 'hidp/includes/forms/logout_form.html' with logout_label=_('Back') %}
 
 {% endblock %}

--- a/packages/hidp/hidp/templates/hidp/otp/verify_recovery_code.html
+++ b/packages/hidp/hidp/templates/hidp/otp/verify_recovery_code.html
@@ -14,5 +14,4 @@
   </form>
 
   {% include 'hidp/includes/forms/logout_form.html' with logout_label=_('Back') %}
-
 {% endblock %}


### PR DESCRIPTION
When the user has to verify their device through the OTP flow, the option to cancel and go back to login is missing. That will mean that if the user, for whatever reason, cannot verify their device, they won't have an option to go back to the main application as the HIdP middleware keeps rerouting them to /manage/otp/verify url. 

I looked into the OWASP documentation. They do suggest that a user always should have an option to 'cancel' the login flow, but as far as I checked I did not see specific suggestions on how the flow should work. 

We've checked how for example GitHub does it, and they have a "back" url that logs the user out of their session and redirects to the /login url. I tried to replicate that flow.

The `user_needs_to_verify` method defaults to True, like how the middleware also does. But I'd like to hear if there are any suggestions on how to enhance this.