### PR TITLE
HIDP-238 - Use EmailField in login form

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -126,6 +126,12 @@ class AuthenticationForm(auth_forms.AuthenticationForm):
     to change the username field to a different one, such as an email address.
     """
 
+    username = forms.EmailField(
+        label=_("Email"),
+        max_length=254,
+        widget=forms.EmailInput(attrs={"autocomplete": "email", "autofocus": True}),
+        required=True,
+    )
     template_name = "hidp/accounts/forms/authentication_form.html"
 
     def __init__(self, request=None, *args, **kwargs):


### PR DESCRIPTION
This popped up in testing the styling of the Django-admin package. The login form has the email field rendered as `<input type="text" />`.

This means that a lot of browser validation misses, and also some further accessibility and password-manager problems may occur. Also there are some nice things like iOS automatically showing an '@' in the keyboard for this field. Since we map the username to always be the email, I think it is safe to also use the EmailField in the authentication form, we also do this in the `PasswordResetRequestForm`. 

```python
...
# Fields
email = forms.EmailField(
    label=_("Email"),
    max_length=254,
    widget=forms.EmailInput(attrs={"autocomplete": "email"}),
)
```