### PR TITLE
[HIDP-242] Move account_management_links function to utils

### DIFF
--- a/packages/hidp/hidp/accounts/views.py
+++ b/packages/hidp/hidp/accounts/views.py
@@ -21,7 +21,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from django.views.decorators.cache import never_cache
 
-from hidp.utils import is_registration_enabled
+from hidp.utils import get_account_management_links, is_registration_enabled
 
 from ..config import oidc_clients
 from ..csp.decorators import hidp_csp_protection
@@ -827,56 +827,11 @@ class ManageAccountView(LoginRequiredMixin, OIDCContextMixin, generic.TemplateVi
 
     template_name = "hidp/accounts/management/manage_account.html"
 
-    def get_account_management_links(self):
-        links = [
-            {
-                "url": reverse("hidp_account_management:edit_account"),
-                "text": _("Edit account"),
-            },
-            {
-                "url": reverse("hidp_account_management:email_change_request"),
-                "text": _("Change email address"),
-            },
-        ]
-
-        if self.request.user.has_usable_password():
-            links.append(
-                {
-                    "url": reverse("hidp_account_management:change_password"),
-                    "text": _("Change password"),
-                },
-            )
-        else:
-            links.append(
-                {
-                    "url": reverse("hidp_account_management:set_password"),
-                    "text": _("Set a password"),
-                },
-            )
-
-        if oidc_clients.get_registered_oidc_clients():
-            links.append(
-                {
-                    "url": reverse("hidp_oidc_management:linked_services"),
-                    "text": _("Linked services"),
-                },
-            )
-
-        if "hidp.otp" in settings.INSTALLED_APPS:
-            links.append(
-                {
-                    "url": reverse("hidp_otp_management:manage"),
-                    "text": _("Two-factor authentication"),
-                },
-            )
-
-        return links
-
     def get_context_data(self, **kwargs):
         context = {
             "user": self.request.user,
             "logout_url": reverse("hidp_accounts:logout"),
-            "account_management_links": self.get_account_management_links(),
+            "account_management_links": get_account_management_links(self.request.user),
         }
         return super().get_context_data() | context | kwargs
 

--- a/packages/hidp/hidp/locale/django.pot
+++ b/packages/hidp/hidp/locale/django.pot
@@ -158,55 +158,12 @@ msgid "Authenticate with {provider}"
 msgstr ""
 
 #: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/email_change_complete.html
-#: hidp/templates/hidp/accounts/management/email_change_request.html
-#: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "Change email address"
-msgstr ""
-
-#: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/password_change.html
-#: hidp/templates/hidp/accounts/management/password_change_done.html
-#: hidp/templates/hidp/accounts/recovery/password_reset.html
-msgid "Change password"
-msgstr ""
-
-#: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/edit_account.html
-#: hidp/templates/hidp/accounts/management/edit_account_done.html
-msgid "Edit account"
-msgstr ""
-
-#: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/set_password.html
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Linked services"
-msgstr ""
-
-#: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/email_change_request.html
-#: hidp/templates/hidp/accounts/management/set_password.html
-#: hidp/templates/hidp/accounts/management/set_password_done.html
-#: hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
-msgid "Set a password"
-msgstr ""
-
-#: hidp/accounts/views.py
 #, python-brace-format
 msgid "Sign up using {provider}"
 msgstr ""
 
 #: hidp/accounts/views.py
 msgid "Sorry, changing your email address is not possible because an account with this email address already exists."
-msgstr ""
-
-#: hidp/accounts/views.py hidp/templates/hidp/otp/disable.html
-#: hidp/templates/hidp/otp/disable_recovery_code.html
-#: hidp/templates/hidp/otp/overview.html
-#: hidp/templates/hidp/otp/recovery_codes.html
-#: hidp/templates/hidp/otp/verify.html
-#: hidp/templates/hidp/otp/verify_recovery_code.html
-msgid "Two-factor authentication"
 msgstr ""
 
 #: hidp/federated/forms.py
@@ -361,6 +318,11 @@ msgid "Sign out"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/edit_account.html
+#: hidp/templates/hidp/accounts/management/edit_account_done.html hidp/utils.py
+msgid "Edit account"
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/edit_account.html
 #: hidp/templates/hidp/accounts/management/edit_account_done.html
 msgid "Edit your account information"
 msgstr ""
@@ -477,6 +439,13 @@ msgid "The request to change your account email address has been successfully ca
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
+#: hidp/templates/hidp/accounts/management/email_change_request.html
+#: hidp/templates/hidp/accounts/management/email_change_request_sent.html
+#: hidp/utils.py
+msgid "Change email address"
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email_change_complete.html
 msgid "Please also confirm the change from your current email address."
 msgstr ""
 
@@ -526,6 +495,14 @@ msgid "Enter the email address you would like to use for your account."
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
+#: hidp/templates/hidp/accounts/management/set_password.html
+#: hidp/templates/hidp/accounts/management/set_password_done.html
+#: hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
+#: hidp/utils.py
+msgid "Set a password"
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/email_change_request.html
 msgid "To change your account email address, please set a password first."
 msgstr ""
 
@@ -565,6 +542,12 @@ msgstr ""
 msgid "You are currently logged in as %(user)s."
 msgstr ""
 
+#: hidp/templates/hidp/accounts/management/password_change.html
+#: hidp/templates/hidp/accounts/management/password_change_done.html
+#: hidp/templates/hidp/accounts/recovery/password_reset.html hidp/utils.py
+msgid "Change password"
+msgstr ""
+
 #: hidp/templates/hidp/accounts/management/set_password.html
 msgid "Add a password to your account. This will allow you to sign in using your email address and password as well as any linked services."
 msgstr ""
@@ -575,6 +558,11 @@ msgstr ""
 
 #: hidp/templates/hidp/accounts/management/set_password.html
 msgid "However, your account is not currently linked to any service, so you cannot set a password at this time."
+msgstr ""
+
+#: hidp/templates/hidp/accounts/management/set_password.html
+#: hidp/templates/hidp/federated/linked_services.html hidp/utils.py
+msgid "Linked services"
 msgstr ""
 
 #: hidp/templates/hidp/accounts/management/set_password_done.html
@@ -825,6 +813,15 @@ msgstr ""
 #: hidp/templates/hidp/otp/disable.html hidp/templates/hidp/otp/verify.html
 #, python-format
 msgid "If you have lost your device, you can <a href=\"%(recovery_code_url)s\">use a recovery code</a> instead."
+msgstr ""
+
+#: hidp/templates/hidp/otp/disable.html
+#: hidp/templates/hidp/otp/disable_recovery_code.html
+#: hidp/templates/hidp/otp/overview.html
+#: hidp/templates/hidp/otp/recovery_codes.html
+#: hidp/templates/hidp/otp/verify.html
+#: hidp/templates/hidp/otp/verify_recovery_code.html hidp/utils.py
+msgid "Two-factor authentication"
 msgstr ""
 
 #: hidp/templates/hidp/otp/disable.html

--- a/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
+++ b/packages/hidp/hidp/locale/nl/LC_MESSAGES/django.po
@@ -159,40 +159,6 @@ msgid "Authenticate with {provider}"
 msgstr "Opnieuw inloggen met {provider}"
 
 #: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/email_change_complete.html
-#: hidp/templates/hidp/accounts/management/email_change_request.html
-#: hidp/templates/hidp/accounts/management/email_change_request_sent.html
-msgid "Change email address"
-msgstr "Wijzig e-mailadres"
-
-#: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/password_change.html
-#: hidp/templates/hidp/accounts/management/password_change_done.html
-#: hidp/templates/hidp/accounts/recovery/password_reset.html
-msgid "Change password"
-msgstr "Wachtwoord wijzigen"
-
-#: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/edit_account.html
-#: hidp/templates/hidp/accounts/management/edit_account_done.html
-msgid "Edit account"
-msgstr "Account bewerken"
-
-#: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/set_password.html
-#: hidp/templates/hidp/federated/linked_services.html
-msgid "Linked services"
-msgstr "Gekoppelde diensten"
-
-#: hidp/accounts/views.py
-#: hidp/templates/hidp/accounts/management/email_change_request.html
-#: hidp/templates/hidp/accounts/management/set_password.html
-#: hidp/templates/hidp/accounts/management/set_password_done.html
-#: hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
-msgid "Set a password"
-msgstr "Wachtwoord instellen"
-
-#: hidp/accounts/views.py
 #, python-brace-format
 msgid "Sign up using {provider}"
 msgstr "Registreer met {provider}"
@@ -200,15 +166,6 @@ msgstr "Registreer met {provider}"
 #: hidp/accounts/views.py
 msgid "Sorry, changing your email address is not possible because an account with this email address already exists."
 msgstr "Sorry, het wijzigen van je e-mailadres is niet mogelijk omdat er al een account bestaat met dit e-mailadres."
-
-#: hidp/accounts/views.py hidp/templates/hidp/otp/disable.html
-#: hidp/templates/hidp/otp/disable_recovery_code.html
-#: hidp/templates/hidp/otp/overview.html
-#: hidp/templates/hidp/otp/recovery_codes.html
-#: hidp/templates/hidp/otp/verify.html
-#: hidp/templates/hidp/otp/verify_recovery_code.html
-msgid "Two-factor authentication"
-msgstr "Tweefactor­authenticatie"
 
 #: hidp/federated/forms.py
 msgid "Yes, I want to link this account"
@@ -362,6 +319,11 @@ msgid "Sign out"
 msgstr "Uitloggen"
 
 #: hidp/templates/hidp/accounts/management/edit_account.html
+#: hidp/templates/hidp/accounts/management/edit_account_done.html hidp/utils.py
+msgid "Edit account"
+msgstr "Account bewerken"
+
+#: hidp/templates/hidp/accounts/management/edit_account.html
 #: hidp/templates/hidp/accounts/management/edit_account_done.html
 msgid "Edit your account information"
 msgstr "Bewerk je accountinformatie"
@@ -478,6 +440,13 @@ msgid "The request to change your account email address has been successfully ca
 msgstr "Het verzoek om het e-mailadres van je account te wijzigen is succesvol geannuleerd."
 
 #: hidp/templates/hidp/accounts/management/email_change_complete.html
+#: hidp/templates/hidp/accounts/management/email_change_request.html
+#: hidp/templates/hidp/accounts/management/email_change_request_sent.html
+#: hidp/utils.py
+msgid "Change email address"
+msgstr "Wijzig e-mailadres"
+
+#: hidp/templates/hidp/accounts/management/email_change_complete.html
 msgid "Please also confirm the change from your current email address."
 msgstr "Bevestig ook de wijziging vanaf je huidige e-mailadres."
 
@@ -527,6 +496,14 @@ msgid "Enter the email address you would like to use for your account."
 msgstr "Voer het e-mailadres in dat je voor je account wilt gebruiken."
 
 #: hidp/templates/hidp/accounts/management/email_change_request.html
+#: hidp/templates/hidp/accounts/management/set_password.html
+#: hidp/templates/hidp/accounts/management/set_password_done.html
+#: hidp/templates/hidp/accounts/recovery/email/set_password_subject.txt
+#: hidp/utils.py
+msgid "Set a password"
+msgstr "Wachtwoord instellen"
+
+#: hidp/templates/hidp/accounts/management/email_change_request.html
 msgid "To change your account email address, please set a password first."
 msgstr "Stel eerst een wachtwoord in om het e-mailadres van je account te kunnen wijzigen."
 
@@ -566,6 +543,12 @@ msgstr "Beheer je accountinformatie"
 msgid "You are currently logged in as %(user)s."
 msgstr "Je bent momenteel ingelogd als %(user)s."
 
+#: hidp/templates/hidp/accounts/management/password_change.html
+#: hidp/templates/hidp/accounts/management/password_change_done.html
+#: hidp/templates/hidp/accounts/recovery/password_reset.html hidp/utils.py
+msgid "Change password"
+msgstr "Wachtwoord wijzigen"
+
 #: hidp/templates/hidp/accounts/management/set_password.html
 msgid "Add a password to your account. This will allow you to sign in using your email address and password as well as any linked services."
 msgstr "Stel een wachtwoord in voor je account. Hiermee kun je inloggen met je e-mailadres en wachtwoord, evenals met eventuele gekoppelde diensten."
@@ -577,6 +560,11 @@ msgstr "Voor je veiligheid moet je opnieuw inloggen via een gekoppelde dienst vo
 #: hidp/templates/hidp/accounts/management/set_password.html
 msgid "However, your account is not currently linked to any service, so you cannot set a password at this time."
 msgstr "Er is echter geen enkele dienst aan je account gekoppeld, waardoor je op dit moment geen wachtwoord kunt instellen."
+
+#: hidp/templates/hidp/accounts/management/set_password.html
+#: hidp/templates/hidp/federated/linked_services.html hidp/utils.py
+msgid "Linked services"
+msgstr "Gekoppelde diensten"
 
 #: hidp/templates/hidp/accounts/management/set_password_done.html
 msgid "Your password has been set."
@@ -827,6 +815,15 @@ msgstr "Het uitschakelen van tweefactor­authenticatie maakt je account minder v
 #, python-format
 msgid "If you have lost your device, you can <a href=\"%(recovery_code_url)s\">use a recovery code</a> instead."
 msgstr "Als je je apparaat bent kwijtgeraakt, kun je in plaats daarvan <a href=\"%(recovery_code_url)s\">een herstelcode gebruiken</a>."
+
+#: hidp/templates/hidp/otp/disable.html
+#: hidp/templates/hidp/otp/disable_recovery_code.html
+#: hidp/templates/hidp/otp/overview.html
+#: hidp/templates/hidp/otp/recovery_codes.html
+#: hidp/templates/hidp/otp/verify.html
+#: hidp/templates/hidp/otp/verify_recovery_code.html hidp/utils.py
+msgid "Two-factor authentication"
+msgstr "Tweefactor­authenticatie"
 
 #: hidp/templates/hidp/otp/disable.html
 #: hidp/templates/hidp/otp/disable_recovery_code.html

--- a/packages/hidp/hidp/utils.py
+++ b/packages/hidp/hidp/utils.py
@@ -43,6 +43,9 @@ def get_account_management_links(user):
     Returns:
         list[dict]: A list of link dictionaries with 'url' and 'text' keys.
     """
+    if not user.is_authenticated:
+        return []
+
     links = [
         {
             "url": reverse("hidp_account_management:edit_account"),


### PR DESCRIPTION
After this PR:

- The function `get_account_management_links` is moved to a util so that we can use it more flexibly.

This PR is a prerequisite for https://github.com/leukeleu/django-hidp-wagtail/pull/20