### PR TITLE
[HIDP-243] Improve the otp_token field by specifying max_length, inputmode and pattern

### DIFF
--- a/packages/hidp/hidp/otp/forms.py
+++ b/packages/hidp/hidp/otp/forms.py
@@ -24,39 +24,55 @@ class OTPVerifyFormBase(OTPAuthenticationFormMixin, forms.Form):
     device_class = None
 
     @staticmethod
-    def create_otp_token_field(label, *, is_numeric=False, max_length=None):
+    def create_otp_token_field(label):
         """
         Create a form field for the OTP token.
 
-        Subclasses should use this method to create the form field for the OTP token.
+        Subclasses should use this method to create the form field for the
+        OTP token.
 
         Args:
             label: Field label
-            is_numeric: If True, adds numeric-friendly input hints (mobile optimization)
-            max_length: Maximum length of the field (default 6 for TOTP, 8 for Static)
 
         Returns:
             Configured CharField
         """
         attrs = {
             "autocomplete": "one-time-code",
+            "maxlength": "6",
+            "inputmode": "numeric",
+            "pattern": "[0-9]*",
         }
-
-        if max_length:
-            attrs["maxlength"] = str(max_length)
-
-        if is_numeric:
-            attrs.update(
-                {
-                    "inputmode": "numeric",  # triggers number pad on mobile
-                    "pattern": "[0-9]*",  # hints at numeric-only (HTML5 pattern)
-                }
-            )
 
         return forms.CharField(
             widget=forms.TextInput(attrs=attrs),
             label=label,
-            max_length=max_length,
+            max_length=6,
+        )
+
+    @staticmethod
+    def create_recovery_code_field(label):
+        """
+        Create a form field for the recovery code.
+
+        Subclasses should use this method to create the form field for the
+        recovery code.
+
+        Args:
+            label: Field label
+
+        Returns:
+            Configured CharField
+        """
+        attrs = {
+            "autocomplete": "one-time-code",
+            "maxlength": "8",
+        }
+
+        return forms.CharField(
+            widget=forms.TextInput(attrs=attrs),
+            label=label,
+            max_length=8,
         )
 
     def __init__(self, user, *args, **kwargs):
@@ -89,8 +105,6 @@ class VerifyTOTPForm(OTPVerifyFormBase):
     device_class = TOTPDevice
     otp_token = OTPVerifyFormBase.create_otp_token_field(
         label=_("Enter the code from the app"),
-        is_numeric=True,
-        max_length=6,
     )
 
 
@@ -103,17 +117,14 @@ class VerifyStaticTokenForm(OTPVerifyFormBase):
     """
 
     device_class = StaticDevice
-    otp_token = OTPVerifyFormBase.create_otp_token_field(
+    otp_token = OTPVerifyFormBase.create_recovery_code_field(
         label=_("Enter a recovery code"),
-        max_length=8,
     )
 
 
 class OTPSetupForm(OTPVerifyFormBase):
     otp_token = OTPVerifyFormBase.create_otp_token_field(
         label=_("Enter the code from the app"),
-        is_numeric=True,
-        max_length=6,
     )
     confirm_stored_backup_tokens = forms.BooleanField(
         required=True,

--- a/packages/hidp/hidp/otp/forms.py
+++ b/packages/hidp/hidp/otp/forms.py
@@ -28,9 +28,6 @@ class OTPVerifyFormBase(OTPAuthenticationFormMixin, forms.Form):
         """
         Create a form field for the OTP token.
 
-        Subclasses should use this method to create the form field for the
-        OTP token.
-
         Args:
             label: Field label
 
@@ -39,7 +36,6 @@ class OTPVerifyFormBase(OTPAuthenticationFormMixin, forms.Form):
         """
         attrs = {
             "autocomplete": "one-time-code",
-            "maxlength": "6",
             "inputmode": "numeric",
             "pattern": "[0-9]*",
         }
@@ -55,9 +51,6 @@ class OTPVerifyFormBase(OTPAuthenticationFormMixin, forms.Form):
         """
         Create a form field for the recovery code.
 
-        Subclasses should use this method to create the form field for the
-        recovery code.
-
         Args:
             label: Field label
 
@@ -65,8 +58,7 @@ class OTPVerifyFormBase(OTPAuthenticationFormMixin, forms.Form):
             Configured CharField
         """
         attrs = {
-            "autocomplete": "one-time-code",
-            "maxlength": "8",
+            "autocomplete": "off",
         }
 
         return forms.CharField(

--- a/packages/hidp/tests/smoke_tests/test_otp/test_views.py
+++ b/packages/hidp/tests/smoke_tests/test_otp/test_views.py
@@ -87,23 +87,24 @@ class TestOTPDisable(TestCase):
         )
 
     def test_static_token_not_accepted(self):
+        """The *static_token* should not be accepted in the *otp_token* disable form."""
         otp_factories.TOTPDeviceFactory(user=self.user, confirmed=True)
         static_device = otp_factories.StaticDeviceFactory(
             user=self.user, confirmed=True
         )
         otp_factories.StaticTokenFactory.create_batch(9, device=static_device)
-        otp_factories.StaticTokenFactory(token="a1b2c3d4", device=static_device)
+        otp_factories.StaticTokenFactory(token="a1b2c3", device=static_device)
         self.client.force_login(self.user)
 
         form_data = {
-            "otp_token": "a1b2c3d4",
+            "otp_token": "a1b2c3",
         }
         response = self.client.post(reverse("hidp_otp_management:disable"), form_data)
         form = response.context["form"]
         self.assertFalse(form.is_valid(), msg="Expected form to be invalid")
         # Check that the error is on the token field
         errors = form.errors.as_data()
-        self.assertEqual(errors["__all__"][0].code, "token_required")
+        self.assertEqual(errors["__all__"][0].code, "invalid_token")
         self.assertTrue(
             self.user.totpdevice_set.exists(),
             msg="Expected the user to have TOTP devices",
@@ -280,7 +281,7 @@ class TestOTPSetupView(TestCase):
         """An invalid form should not confirm the TOTP and static devices."""
         self.client.force_login(self.user)
         form_data = {
-            "otp_token": "000000",
+            "otp_token": "xxxxxx",  # Invalid token
             "confirm_stored_backup_tokens": True,
         }
         response = self.client.post(reverse("hidp_otp_management:setup"), form_data)
@@ -373,7 +374,7 @@ class TestOTPVerifyView(TestCase):
     def test_invalid_form_does_not_verify_user(self):
         otp_factories.TOTPDeviceFactory(user=self.user, confirmed=True)
         self.client.force_login(self.user)
-        form_data = {"otp_token": "000000"}
+        form_data = {"otp_token": "xxxxxx"}  # Invalid token
         response = self.client.post(reverse("hidp_otp:verify"), form_data)
         form = response.context["form"]
         self.assertFalse(form.is_valid(), msg="Expected form to be invalid")
@@ -425,7 +426,7 @@ class TestOTPVerifyWithRecoveryCodeView(TestCase):
         device = otp_factories.StaticDeviceFactory(user=self.user, confirmed=True)
         otp_factories.StaticTokenFactory.create_batch(10, device=device)
         self.client.force_login(self.user)
-        form_data = {"otp_token": "000000"}
+        form_data = {"otp_token": "xxxxxx"}  # Invalid token
         response = self.client.post(reverse("hidp_otp:verify-recovery-code"), form_data)
         form = response.context["form"]
         self.assertFalse(form.is_valid(), msg="Expected form to be invalid")

--- a/packages/hidp/tests/smoke_tests/test_otp/test_views.py
+++ b/packages/hidp/tests/smoke_tests/test_otp/test_views.py
@@ -92,18 +92,18 @@ class TestOTPDisable(TestCase):
             user=self.user, confirmed=True
         )
         otp_factories.StaticTokenFactory.create_batch(9, device=static_device)
-        otp_factories.StaticTokenFactory(token="static-token", device=static_device)
+        otp_factories.StaticTokenFactory(token="a1b2c3d4", device=static_device)
         self.client.force_login(self.user)
 
         form_data = {
-            "otp_token": "static-token",
+            "otp_token": "a1b2c3d4",
         }
         response = self.client.post(reverse("hidp_otp_management:disable"), form_data)
         form = response.context["form"]
         self.assertFalse(form.is_valid(), msg="Expected form to be invalid")
         # Check that the error is on the token field
         errors = form.errors.as_data()
-        self.assertEqual(errors["__all__"][0].code, "invalid_token")
+        self.assertEqual(errors["__all__"][0].code, "token_required")
         self.assertTrue(
             self.user.totpdevice_set.exists(),
             msg="Expected the user to have TOTP devices",
@@ -136,11 +136,11 @@ class TestOTPDisableWithRecoveryCode(TestCase):
             user=self.user, confirmed=True
         )
         otp_factories.StaticTokenFactory.create_batch(9, device=static_device)
-        otp_factories.StaticTokenFactory(device=static_device, token="static-token")
+        otp_factories.StaticTokenFactory(device=static_device, token="a1b2c3d4")
         self.client.force_login(self.user)
 
         form_data = {
-            "otp_token": "static-token",
+            "otp_token": "a1b2c3d4",
         }
         with (
             self.assertTemplateUsed("hidp/otp/email/disabled_subject.txt"),
@@ -280,7 +280,7 @@ class TestOTPSetupView(TestCase):
         """An invalid form should not confirm the TOTP and static devices."""
         self.client.force_login(self.user)
         form_data = {
-            "otp_token": "invalid",
+            "otp_token": "000000",
             "confirm_stored_backup_tokens": True,
         }
         response = self.client.post(reverse("hidp_otp_management:setup"), form_data)
@@ -373,7 +373,7 @@ class TestOTPVerifyView(TestCase):
     def test_invalid_form_does_not_verify_user(self):
         otp_factories.TOTPDeviceFactory(user=self.user, confirmed=True)
         self.client.force_login(self.user)
-        form_data = {"otp_token": "invalid"}
+        form_data = {"otp_token": "000000"}
         response = self.client.post(reverse("hidp_otp:verify"), form_data)
         form = response.context["form"]
         self.assertFalse(form.is_valid(), msg="Expected form to be invalid")
@@ -425,7 +425,7 @@ class TestOTPVerifyWithRecoveryCodeView(TestCase):
         device = otp_factories.StaticDeviceFactory(user=self.user, confirmed=True)
         otp_factories.StaticTokenFactory.create_batch(10, device=device)
         self.client.force_login(self.user)
-        form_data = {"otp_token": "invalid"}
+        form_data = {"otp_token": "000000"}
         response = self.client.post(reverse("hidp_otp:verify-recovery-code"), form_data)
         form = response.context["form"]
         self.assertFalse(form.is_valid(), msg="Expected form to be invalid")


### PR DESCRIPTION
After this PR:

- We can specify max_length (different for otp_tokens than for recovery codes)
- inputmode=numeric is added when is_numeric is True for showing a numeric keyboard on mobile
- pattern is specified when is_numeric is True

For now I hardcoded the default values for max_length to 6 for otp_token and 8 for the recovery code. I noticed that it's not specified anywhere so maybe we need to DO specify it in a central location somewhere so we can use that setting everywhere?