### PR TITLE
Fix password field names and make required when setting password

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -292,16 +292,16 @@ class SetPasswordForm(auth_forms.SetPasswordForm):
     template_name = "hidp/accounts/management/forms/set_password_form.html"
 
     # Fields
-    password1 = forms.CharField(
+    new_password1 = forms.CharField(
         label=_("Password"),
-        required=False,
+        required=True,
         strip=False,
         widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
         help_text=django_password_validation.password_validators_help_text_html(),
     )
-    password2 = forms.CharField(
+    new_password2 = forms.CharField(
         label=_("Password confirmation"),
-        required=False,
+        required=True,
         widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
         strip=False,
         help_text=_("Enter the same password as before, for verification."),


### PR DESCRIPTION
From discussion https://github.com/leukeleu/django-hidp/pull/342#discussion_r2093059326

The block of code in `hidp.accounts.forms.SetPasswordForm` has the role of creating the password fields which is handled by `SetPasswordMixin.create_password_fields` which is only added in [Django 5](https://github.com/django/django/blob/994dc6d8a1bae717baa236b65e11cf91ce181c53/django/contrib/auth/forms.py#L89). In Django 4.2, the same SetPasswordForm contains the following code on password fields:

```
    new_password1 = forms.CharField(
        label=_("New password"),
        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
        strip=False,
        help_text=password_validation.password_validators_help_text_html(),
    )
    new_password2 = forms.CharField(
        label=_("New password confirmation"),
        strip=False,
        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
    )
```

So also not required and with hardcoded label reference to `New password ...`

I feel like we should add some comment in the code about this aswell but not sure what makes most sense?