### PR TITLE
Add default Python and Django version for building docs

### DIFF
--- a/.github/actions/build-hidp-docs/action.yml
+++ b/.github/actions/build-hidp-docs/action.yml
@@ -9,6 +9,8 @@ runs:
       uses: ./.github/actions/setup-python
       with:
         working-directory: './packages/hidp'
+        python-version: '3.13'
+        django-version: '5.2'
 
     - name: Build documentation
       run: |


### PR DESCRIPTION
Deploying docs [goes wrong](https://github.com/leukeleu/django-hidp/actions/runs/15107188196/job/42458265498) since no `python-version` or `django-version` is specified for the `Build documentation` step in `deploy-docs`.

Perhaps it makes more sense to add defaults to `setup-python.yml` itself a la:

```
  python-version:
    description: The Python version to use
    default: '3.12'
  django-version:
    description: The Django version to use as dependency
    default: '4.2'
```


   