### PR TITLE
Fetch entire repository, including tags, to get the proper version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # A build is created as part of the QA job
       - name: Linting, checks & tests


### PR DESCRIPTION
This PR changes the behavior of the actions/checkout so that the entire repository is fetched, and not just the latest commit. The default value of fetch-depth is 1, where it will only fetch the latest commit, see [here](https://github.com/actions/checkout/blob/main/README.md#usage).

This follows from the following documentation:

- https://github.com/actions/checkout/issues/1471 (describing that fetch-tags does not work)
- https://github.com/authzed/spicedb/pull/1887/files adding the same fetch-depth 0 to fix their versioning issue.

