### PR TITLE
[HIDP-247] Make sure otp verification forms are output using divs

### DIFF
--- a/packages/hidp/hidp/otp/forms.py
+++ b/packages/hidp/hidp/otp/forms.py
@@ -20,6 +20,8 @@ class OTPAuthenticationFormMixin(DjangoOTPAuthenticationFormMixin):
 
 
 class OTPVerifyFormBase(OTPAuthenticationFormMixin, forms.Form):
+    template_name = "hidp/otp/forms/otp_verify_form.html"
+
     # The device class to use for verification, e.g. TOTPDevice or StaticDevice.
     device_class = None
 

--- a/packages/hidp/hidp/templates/hidp/otp/forms/otp_verify_form.html
+++ b/packages/hidp/hidp/templates/hidp/otp/forms/otp_verify_form.html
@@ -1,0 +1,1 @@
+{% extends 'hidp/includes/forms/base_form.html' %}


### PR DESCRIPTION
The form fields in the otp verify views are not wrapped in `<div>`s while all other form field are. This PR makes sure the forms extending from `OTPVerifyFormBase` are wrapped in `<div>`s, making the rendering of these forms now consistent with other forms. 