### PR TITLE
[HIDP-256] Send next_param to recovery_code view if given

### DIFF
--- a/packages/hidp/hidp/templates/hidp/otp/verify.html
+++ b/packages/hidp/hidp/templates/hidp/otp/verify.html
@@ -14,7 +14,6 @@
   </form>
 
   <p>
-    {% url 'hidp_otp:verify-recovery-code' as recovery_code_url %}
     {% blocktranslate trimmed %}
       If you have lost your device, you can <a href="{{ recovery_code_url }}">use a recovery code</a> instead.
     {% endblocktranslate %}


### PR DESCRIPTION
This PR solves an issue where, if the user uses the recovery code view, the next param is lost.