### PR TITLE
LKL-2373 Use setup-uv 

### DIFF
--- a/.github/actions/build-hidp-docs/action.yml
+++ b/.github/actions/build-hidp-docs/action.yml
@@ -15,7 +15,6 @@ runs:
     - name: Build documentation
       run: |
         echo ::group::Build documentation
-        source ~/.venv/bin/activate
         make html
         echo ::endgroup::
       working-directory: './packages/hidp/docs'

--- a/.github/actions/python-qa/action.yml
+++ b/.github/actions/python-qa/action.yml
@@ -22,7 +22,6 @@ runs:
 
     - name: Lint, check, test and build (if applicable)
       run: |
-        source ~/.venv/bin/activate
         UV_DJANGO_VERSION=$(uv pip list | sed -nE 's/^django[[:space:]]+([0-9]+\.[0-9]+)\..*/\1/p')
         echo "Detected uv Django version: $UV_DJANGO_VERSION"
         echo "Expected Django version: $DJANGO_VERSION"

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -13,10 +13,12 @@ runs:
   using: composite
 
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v5
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ inputs.python-version }}
+        activate-environment: true
+        enable-cache: true
 
     - name: Install system packages (gettext)
       run: |
@@ -24,14 +26,6 @@ runs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends gettext
         echo ::endgroup::
-      shell: bash
-
-    - name: Install uv
-      run: |
-        echo ::group::Install uv
-        python -m pip install --root-user-action=ignore -U uv
-        echo ::endgroup::
-      working-directory: ${{ inputs.working-directory }}
       shell: bash
 
     - name: Set Django version
@@ -43,10 +37,6 @@ runs:
 
     - name: Install dependencies
       run: |
-        echo ::group::Create/activate virtualenv
-        uv venv ~/.venv
-        source ~/.venv/bin/activate
-        echo ::endgroup::
         make install-pipeline
       working-directory: ${{ inputs.working-directory }}
       shell: bash


### PR DESCRIPTION
`setup-uv` is being used in Github Actions instead of `setup-python`.  Uv takes care of python installation and eliminates the need to activate venv in each step