### PR TITLE
FIT-134 Hide password hints and helptext when signing up

### DIFF
--- a/packages/hidp/hidp/accounts/forms.py
+++ b/packages/hidp/hidp/accounts/forms.py
@@ -59,6 +59,16 @@ class UserCreationForm(TermsOfServiceMixin, auth_forms.BaseUserCreationForm):
         model = UserModel
         fields = (UserModel.USERNAME_FIELD,)
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # only show helptext for password fields if there are any errors
+        # Errors appear on password2 field for some reason,
+        # so just disable help text on both
+        if not self.has_error("password1") and not self.has_error("password2"):
+            self.fields["password1"].help_text = ""
+            self.fields["password2"].help_text = ""
+
     def _get_validation_exclusions(self):
         # Exclude email from model validation (unique constraint),
         # This will make the form valid even if the email is already in use.


### PR DESCRIPTION
- Only show help text if there are errors on registration form.

<details>
<summary>Form without any errors</summary>

<img width="480" height="622" alt="Screenshot 2025-10-07 at 17 25 32" src="https://github.com/user-attachments/assets/82efd2b7-0641-44e3-9977-333a2682869e" />

</details>

<details>
<summary>Form after user has submitted with invalid inputs</summary>

<img width="511" height="751" alt="Screenshot 2025-10-07 at 17 25 50" src="https://github.com/user-attachments/assets/f944914b-0a7e-43f7-b26f-5d39adb0b9bb" />

</details>
