### PR TITLE
Delete django-hidp setup.py

### DIFF
--- a/packages/hidp/setup.py
+++ b/packages/hidp/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
This is no longer used, replaced by pyproject.toml.